### PR TITLE
Use PolicyNet and ValueNet in AVEC + Create utils/memories.py

### DIFF
--- a/rlberry/agents/a2c/a2c.py
+++ b/rlberry/agents/a2c/a2c.py
@@ -103,8 +103,7 @@ class A2CAgent(IncrementalAgent):
                                                 lr=self.learning_rate,
                                                 betas=(0.9, 0.999))
 
-        self.cat_policy_old = \
-            PolicyNet(self.state_dim, self.action_dim).to(device)
+        self.cat_policy_old = PolicyNet(self.state_dim, self.action_dim).to(device)
         self.cat_policy_old.load_state_dict(self.cat_policy.state_dict())
 
         self.MseLoss = nn.MSELoss()

--- a/rlberry/agents/a2c/a2c.py
+++ b/rlberry/agents/a2c/a2c.py
@@ -5,26 +5,11 @@ import torch.nn as nn
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
+from rlberry.agents.utils.memories import Memory
 from rlberry.agents.utils.torch_models import PolicyNet, ValueNet
 
 # choose device
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-class Memory:
-    def __init__(self):
-        self.actions = []
-        self.states = []
-        self.logprobs = []
-        self.rewards = []
-        self.is_terminals = []
-
-    def clear_memory(self):
-        del self.actions[:]
-        del self.states[:]
-        del self.logprobs[:]
-        del self.rewards[:]
-        del self.is_terminals[:]
 
 
 class A2CAgent(IncrementalAgent):

--- a/rlberry/agents/avec/avec_ppo.py
+++ b/rlberry/agents/avec/avec_ppo.py
@@ -5,26 +5,10 @@ import torch
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
-
+from rlberry.agents.utils.memories import Memory
 from rlberry.agents.utils.torch_models import ValueNet, PolicyNet
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-class Memory:
-    def __init__(self):
-        self.actions = []
-        self.states = []
-        self.logprobs = []
-        self.rewards = []
-        self.is_terminals = []
-
-    def clear_memory(self):
-        del self.actions[:]
-        del self.states[:]
-        del self.logprobs[:]
-        del self.rewards[:]
-        del self.is_terminals[:]
 
 
 class AVECPPOAgent(IncrementalAgent):

--- a/rlberry/agents/cem/cem.py
+++ b/rlberry/agents/cem/cem.py
@@ -7,34 +7,12 @@ import torch.nn as nn
 import rlberry.seeding as seeding
 import gym.spaces as spaces
 from rlberry.agents import Agent
+from rlberry.agents.utils.memories import CEMMemory
 
 # choose device
 from rlberry.agents.utils.torch_models import Net
 
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-class Memory:
-    def __init__(self, max_size):
-        self.max_size = max_size
-        self.clear()
-
-    def clear(self):
-        self.size = 0
-        self.states = []
-        self.actions = []
-        self.rewards = []
-
-    def append(self, state, action, reward):
-        self.states.append(state)
-        self.actions.append(action)
-        self.rewards.append(reward)
-        self.size += 1
-        if self.size == self.max_size+1:
-            self.states.pop(0)
-            self.actions.pop(0)
-            self.rewards.pop(0)
-            self.size = self.max_size
 
 
 class CEMAgent(Agent):
@@ -102,7 +80,7 @@ class CEMAgent(Agent):
                                           lr=self.learning_rate)
 
         # memory
-        self.memory = Memory(self.batch_size)
+        self.memory = CEMMemory(self.batch_size)
 
         # logging config
         self._last_printed_ep = 0

--- a/rlberry/agents/dqn/abstract.py
+++ b/rlberry/agents/dqn/abstract.py
@@ -3,7 +3,7 @@ from gym import spaces
 
 from rlberry.agents import Agent
 from rlberry.agents.dqn.exploration import exploration_factory
-from rlberry.agents.dqn.memory import ReplayMemory, Transition
+from rlberry.agents.utils.memories import ReplayMemory, Transition
 
 
 class AbstractDQNAgent(Agent, ABC):

--- a/rlberry/agents/dqn/pytorch.py
+++ b/rlberry/agents/dqn/pytorch.py
@@ -7,7 +7,7 @@ from rlberry.agents.utils.torch_models import trainable_parameters
 from rlberry.agents.utils.torch_training import loss_function_factory
 from rlberry.agents.utils.torch_training import optimizer_factory
 from rlberry.agents.dqn.abstract import AbstractDQNAgent
-from rlberry.agents.dqn.memory import Transition
+from rlberry.agents.utils.memories import Transition
 from rlberry.utils.torch import choose_device
 
 logger = logging.getLogger(__name__)

--- a/rlberry/agents/ppo/ppo.py
+++ b/rlberry/agents/ppo/ppo.py
@@ -6,26 +6,11 @@ import torch.nn as nn
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
+from rlberry.agents.utils.memories import Memory
 from rlberry.agents.utils.torch_models import ValueNet, PolicyNet
 
 # choose device
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
-
-
-class Memory:
-    def __init__(self):
-        self.actions = []
-        self.states = []
-        self.logprobs = []
-        self.rewards = []
-        self.is_terminals = []
-
-    def clear_memory(self):
-        del self.actions[:]
-        del self.states[:]
-        del self.logprobs[:]
-        del self.rewards[:]
-        del self.is_terminals[:]
 
 
 class PPOAgent(IncrementalAgent):

--- a/rlberry/agents/utils/memories.py
+++ b/rlberry/agents/utils/memories.py
@@ -110,3 +110,42 @@ class ReplayMemory(object):
 
     def is_empty(self):
         return len(self.memory) == 0
+
+
+class Memory:
+    def __init__(self):
+        self.actions = []
+        self.states = []
+        self.logprobs = []
+        self.rewards = []
+        self.is_terminals = []
+
+    def clear_memory(self):
+        del self.actions[:]
+        del self.states[:]
+        del self.logprobs[:]
+        del self.rewards[:]
+        del self.is_terminals[:]
+
+
+class CEMMemory:
+    def __init__(self, max_size):
+        self.max_size = max_size
+        self.clear()
+
+    def clear(self):
+        self.size = 0
+        self.states = []
+        self.actions = []
+        self.rewards = []
+
+    def append(self, state, action, reward):
+        self.states.append(state)
+        self.actions.append(action)
+        self.rewards.append(reward)
+        self.size += 1
+        if self.size == self.max_size+1:
+            self.states.pop(0)
+            self.actions.pop(0)
+            self.rewards.pop(0)
+            self.size = self.max_size


### PR DESCRIPTION
This PR does the following:
* Similar to what has been done for A2C and PPO, remove `ActorCritic` usage and use existing `PolicyNet` and `ValueNet`.
* Cleanup Memory class by removing the duplicate in-file creations: now DQN, PPO, A2C, AVEC, CEM import their memories from the Memory classes in `rlberry/agents/utils/memories.py`.