### PR TITLE
Use logging for logging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,3 +88,18 @@ class MyAgent(Agent):
 ```
 
 __Remark__: For a faster hyperparameter optimization, it is recommended to implement the `partial_fit()` function in the `IncrementalAgent` interface (`rlberry/agents/incremental_agent.py`), in which case the agent must inherit from `IncrementalAgent`.
+
+
+## Guidelines for logging
+
+*   `logger.info()`, `logger.warning()` and `logger.error()` should be used inside the `rlberry` package, rather than `print()`.
+*    The desired level of verbosity can be chosen by calling `configure_logging`, e.g.:
+
+```python
+from rlberry.utils.logging import configure_logging
+configure_logging(level="DEBUG")
+configure_logging(level="INFO")
+# etc
+```
+
+* `print()` statements can be used outside `rlberry`, e.g., in scripts and notebooks.

--- a/README.md
+++ b/README.md
@@ -185,11 +185,7 @@ Want to contribute to `rlberry`? Please check [our contribution guidelines](CONT
 
 *   When inheriting from the `Agent` class, make sure to call `Agent.__init__(self, env, **kwargs)` using `**kwargs` in case new features are added to the base class, and to make sure that `copy_env` and `reseed_env` are always an option to any agent. 
 
-*   Convention for verbose in the agents:
-    *   `verbose=0`: nothing is printed
-    *   `verbose>=1`: print progress messages
-
-Errors and warnings are printed using the `logging` library.
+Infos, errors and warnings are printed using the `logging` library.
 
 *   From `gym` to `rlberry`:
     *   `reseed` (rlberry) should be called instead of `seed` (gym). `seed` keeps compatilibity with gym, whereas `reseed` uses the unified seeding mechanism of `rlberry`.

--- a/examples/demo_a2c.py
+++ b/examples/demo_a2c.py
@@ -2,16 +2,17 @@ from rlberry.agents import A2CAgent
 from rlberry.envs.classic_control import MountainCar
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.seeding import seeding
+from rlberry.utils.logging import configure_logging
 
 render = True
-
 seeding.set_global_seed(1223)
+configure_logging("DEBUG")
 
 for env, n_episodes, horizon in zip([PBall2D(), MountainCar()],
                                     [400, 40000], [256, 512]):
     print("Running A2C on %s" % env.name)
     agent = A2CAgent(env, n_episodes=n_episodes, horizon=horizon,
-                     gamma=0.99, learning_rate=0.001, k_epochs=4, verbose=4)
+                     gamma=0.99, learning_rate=0.001, k_epochs=4)
     agent.fit()
 
     if render:

--- a/examples/demo_acrobot.py
+++ b/examples/demo_acrobot.py
@@ -1,14 +1,16 @@
 from rlberry.envs import Acrobot
 from rlberry.agents import RSUCBVIAgent
+from rlberry.utils.logging import configure_logging
 from rlberry.wrappers import RescaleRewardWrapper
 
+configure_logging("DEBUG")
 
 env = Acrobot()
 # rescale rewards to [0, 1]
 env = RescaleRewardWrapper(env, (0.0, 1.0))
 
 agent = RSUCBVIAgent(env, n_episodes=500, gamma=0.99, horizon=300,
-                     bonus_scale_factor=0.01, min_dist=0.25, verbose=4)
+                     bonus_scale_factor=0.01, min_dist=0.25)
 agent.fit()
 
 env.enable_rendering()

--- a/examples/demo_agent_stats.py
+++ b/examples/demo_agent_stats.py
@@ -1,10 +1,12 @@
+
 import rlberry.seeding as seeding
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.agents import RSKernelUCBVIAgent, RSUCBVIAgent
 from rlberry.agents.ppo import PPOAgent
 from rlberry.stats import AgentStats, plot_episode_rewards, compare_policies
+from rlberry.utils.logging import configure_logging
 
-
+configure_logging("DEBUG")
 # global seed
 seeding.set_global_seed(1234)
 
@@ -23,7 +25,6 @@ GAMMA = 0.99
 HORIZON = 50
 BONUS_SCALE_FACTOR = 0.1
 MIN_DIST = 0.1
-VERBOSE = 4
 
 params = {
     "n_episodes": N_EPISODES,
@@ -31,7 +32,6 @@ params = {
     "horizon": HORIZON,
     "bonus_scale_factor": BONUS_SCALE_FACTOR,
     "min_dist": MIN_DIST,
-    "verbose": VERBOSE
 }
 
 params_kernel = {
@@ -43,7 +43,6 @@ params_kernel = {
     "bandwidth": 0.1,
     "beta": 1.0,
     "kernel_type": "gaussian",
-    "verbose": VERBOSE
 }
 
 params_ppo = {"n_episodes": N_EPISODES,

--- a/examples/demo_agent_stats_pickle.py
+++ b/examples/demo_agent_stats_pickle.py
@@ -22,14 +22,12 @@ GAMMA = 0.99
 HORIZON = 50
 BONUS_SCALE_FACTOR = 0.1
 MIN_DIST = 0.1
-VERBOSE = 4
 
 
 params_ppo = {"n_episodes": N_EPISODES,
               "gamma": GAMMA,
               "horizon": HORIZON,
-              "learning_rate": 0.0003,
-              "verbose": 5}
+              "learning_rate": 0.0003}
 
 # -------------------------------
 # Run AgentStats and save results

--- a/examples/demo_avecppo.py
+++ b/examples/demo_avecppo.py
@@ -6,7 +6,7 @@ for env, n_episodes, horizon in zip([MountainCar()], [40000], [256]):
     print("Running AVECPPO on %s" % env.name)
     agent = AVECPPOAgent(env, n_episodes=n_episodes, horizon=horizon,
                          gamma=0.99, learning_rate=0.00025, eps_clip=0.2,
-                         k_epochs=4, verbose=4)
+                         k_epochs=4)
     agent.fit()
 
     if render:

--- a/examples/demo_cem.py
+++ b/examples/demo_cem.py
@@ -1,8 +1,10 @@
 import numpy as np
 from rlberry.agents.cem import CEMAgent
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
-
 import rlberry.seeding as seeding
+from rlberry.utils.logging import configure_logging
+
+configure_logging(level="DEBUG")
 
 seeding.set_global_seed(123)
 

--- a/examples/demo_dqn.py
+++ b/examples/demo_dqn.py
@@ -3,6 +3,9 @@ from pathlib import Path
 from torch.utils.tensorboard import SummaryWriter
 
 from rlberry.agents.dqn import DQNAgent
+from rlberry.utils.logging import configure_logging
+
+configure_logging(level="DEBUG")
 
 env = gym_make("CartPole-v0")
 agent = DQNAgent(env, n_episodes=50, exploration_kwargs={"tau": 1000})
@@ -10,7 +13,7 @@ agent.set_writer(SummaryWriter())
 
 print(f"Running DQN on {env}")
 print(f"Visualize with tensorboard by \
-running:\n$ tensorboard --logdir {Path(agent.writer.log_dir).parent}")
+running:\n$tensorboard --logdir {Path(agent.writer.log_dir).parent}")
 
 agent.fit()
 

--- a/examples/demo_gym_wrapper.py
+++ b/examples/demo_gym_wrapper.py
@@ -1,6 +1,9 @@
 from rlberry.envs import gym_make
 from rlberry.agents import RSUCBVIAgent
+from rlberry.utils.logging import configure_logging
 from rlberry.wrappers import RescaleRewardWrapper
+
+configure_logging("DEBUG")
 
 env = gym_make('Acrobot-v1')
 env.reward_range = (-1.0, 0.0)  # missing in gym implementation
@@ -9,7 +12,7 @@ env.reward_range = (-1.0, 0.0)  # missing in gym implementation
 env = RescaleRewardWrapper(env, (0.0, 1.0))
 
 agent = RSUCBVIAgent(env, n_episodes=10, gamma=0.99, horizon=200,
-                     bonus_scale_factor=0.1, min_dist=0.2, verbose=4)
+                     bonus_scale_factor=0.1, min_dist=0.2)
 agent.fit()
 
 state = env.reset()

--- a/examples/demo_hyperparam_optim.py
+++ b/examples/demo_hyperparam_optim.py
@@ -2,8 +2,9 @@ import rlberry.seeding as seeding
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.agents.ppo import PPOAgent
 from rlberry.stats import AgentStats
+from rlberry.utils.logging import configure_logging
 
-
+configure_logging("DEBUG")
 # global seed
 seeding.set_global_seed(1234)
 
@@ -22,14 +23,12 @@ GAMMA = 0.99
 HORIZON = 50
 BONUS_SCALE_FACTOR = 0.1
 MIN_DIST = 0.1
-VERBOSE = 4
 
 
 params_ppo = {"n_episodes": N_EPISODES,
               "gamma": GAMMA,
               "horizon": HORIZON,
-              "learning_rate": 0.0003,
-              "verbose": 5}
+              "learning_rate": 0.0003}
 
 # -------------------------------
 # Run AgentStats and save results

--- a/examples/demo_ppo.py
+++ b/examples/demo_ppo.py
@@ -2,9 +2,10 @@ from rlberry.agents import PPOAgent
 from rlberry.envs.classic_control import MountainCar
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.seeding import seeding
+from rlberry.utils.logging import configure_logging
 
 render = False
-
+configure_logging(level="DEBUG")
 seeding.set_global_seed(1223)
 
 for env, n_episodes, horizon in zip([PBall2D(), MountainCar()],
@@ -12,7 +13,7 @@ for env, n_episodes, horizon in zip([PBall2D(), MountainCar()],
     print("Running PPO on %s" % env.name)
     agent = PPOAgent(env, n_episodes=n_episodes, horizon=horizon,
                      gamma=0.99, learning_rate=0.001,
-                     eps_clip=0.2, k_epochs=4, verbose=4)
+                     eps_clip=0.2, k_epochs=4)
     agent.fit()
 
     if render:

--- a/examples/demo_ppo_benchmark.py
+++ b/examples/demo_ppo_benchmark.py
@@ -2,9 +2,11 @@ import rlberry.seeding as seeding
 from rlberry.envs.benchmarks.ball_exploration.ball2d import get_benchmark_env
 from rlberry.agents import MBQVIAgent
 from rlberry.agents.ppo import PPOAgent
+from rlberry.utils.logging import configure_logging
 from rlberry.wrappers import DiscretizeStateWrapper
 from rlberry.stats import AgentStats, plot_episode_rewards, compare_policies
 
+configure_logging("DEBUG")
 
 # global seed
 seeding.set_global_seed(1234)
@@ -22,7 +24,6 @@ d_train_env = DiscretizeStateWrapper(train_env, 20)
 N_EPISODES = 500
 GAMMA = 0.99
 HORIZON = 50
-VERBOSE = 4
 
 params_oracle = {
     "n_samples": 20,  # samples per state-action
@@ -33,8 +34,7 @@ params_oracle = {
 params_ppo = {"n_episodes": N_EPISODES,
               "gamma": GAMMA,
               "horizon": HORIZON,
-              "learning_rate": 0.0003,
-              "verbose": VERBOSE}
+              "learning_rate": 0.0003}
 
 # -----------------------------
 # Run AgentStats

--- a/examples/demo_ppo_partial_fit.py
+++ b/examples/demo_ppo_partial_fit.py
@@ -1,9 +1,12 @@
+
 from rlberry.agents.ppo import PPOAgent
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.seeding import seeding
 from rlberry.stats import AgentStats, plot_episode_rewards, compare_policies
-seeding.set_global_seed(1223)
+from rlberry.utils.logging import configure_logging
 
+seeding.set_global_seed(1223)
+configure_logging(level="DEBUG")
 
 env = PBall2D()
 n_episodes = 400
@@ -16,7 +19,6 @@ ppo_params['gamma'] = 0.99
 ppo_params['learning_rate'] = 0.001
 ppo_params['eps_clip'] = 0.2
 ppo_params['k_epochs'] = 4
-ppo_params['verbose'] = 5
 
 ppo_stats = AgentStats(PPOAgent, env, eval_horizon=100,
                        init_kwargs=ppo_params, n_fit=2)

--- a/examples/demo_rs_kernel_ucbvi.py
+++ b/examples/demo_rs_kernel_ucbvi.py
@@ -1,7 +1,9 @@
 from rlberry.envs import Acrobot
 from rlberry.agents import RSKernelUCBVIAgent
+from rlberry.utils.logging import configure_logging
 from rlberry.wrappers import RescaleRewardWrapper
 
+configure_logging("DEBUG")
 
 env = Acrobot()
 # rescake rewards to [0, 1]
@@ -10,7 +12,7 @@ env = RescaleRewardWrapper(env, (0.0, 1.0))
 agent = RSKernelUCBVIAgent(env, n_episodes=500, gamma=0.99, horizon=300,
                            bonus_scale_factor=0.01,
                            min_dist=0.2, bandwidth=0.05, beta=1.0,
-                           kernel_type="gaussian", verbose=4)
+                           kernel_type="gaussian")
 agent.fit()
 
 env.enable_rendering()

--- a/examples/demo_rsucbvi.py
+++ b/examples/demo_rsucbvi.py
@@ -1,11 +1,14 @@
 from rlberry.agents import RSUCBVIAgent
 from rlberry.envs.classic_control import MountainCar
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
+from rlberry.utils.logging import configure_logging
+
+configure_logging("DEBUG")
 
 for env, horizon in zip([MountainCar(), PBall2D()], [170, 50]):
     print("Running RS-UCBVI on %s" % env.name)
     agent = RSUCBVIAgent(env, n_episodes=1000, gamma=0.99, horizon=horizon,
-                         bonus_scale_factor=0.1, verbose=4)
+                         bonus_scale_factor=0.1)
     agent.fit()
 
     env.enable_rendering()

--- a/rlberry/agents/a2c/a2c.py
+++ b/rlberry/agents/a2c/a2c.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import torch.nn as nn
+import logging
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
@@ -10,6 +11,7 @@ from rlberry.agents.utils.torch_models import default_policy_net_fn
 from rlberry.agents.utils.torch_models import default_value_net_fn
 from rlberry.utils.writers import PeriodicWriter
 
+logger = logging.getLogger(__name__)
 
 # choose device
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -43,8 +45,6 @@ class A2CAgent(IncrementalAgent):
     value_net_fn : function
         Function that returns an instance of a value network (pytorch).
         If None, a default net is used.
-    verbose : int
-        Controls the verbosity, if non zero, progress messages are printed.
 
 
     References
@@ -69,7 +69,6 @@ class A2CAgent(IncrementalAgent):
                  k_epochs=5,
                  policy_net_fn=None,
                  value_net_fn=None,
-                 verbose=1,
                  **kwargs):
         IncrementalAgent.__init__(self, env, **kwargs)
 
@@ -83,7 +82,6 @@ class A2CAgent(IncrementalAgent):
 
         self.state_dim = self.env.observation_space.shape[0]
         self.action_dim = self.env.action_space.n
-        self.verbose = verbose
 
         #
         self.policy_net_fn = policy_net_fn \
@@ -129,9 +127,7 @@ class A2CAgent(IncrementalAgent):
         self._cumul_rewards = np.zeros(self.n_episodes)
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
+        log_every = 5*logger.getEffectiveLevel()
         self.writer = PeriodicWriter(self.name, log_every=log_every)
 
     def policy(self, state, **kwargs):

--- a/rlberry/agents/avec/avec_ppo.py
+++ b/rlberry/agents/avec/avec_ppo.py
@@ -1,5 +1,6 @@
 import numpy as np
 import torch
+import logging
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
@@ -9,6 +10,7 @@ from rlberry.agents.utils.torch_models import default_policy_net_fn
 from rlberry.agents.utils.torch_models import default_value_net_fn
 from rlberry.utils.writers import PeriodicWriter
 
+logger = logging.getLogger(__name__)
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
 
@@ -61,8 +63,6 @@ class AVECPPOAgent(IncrementalAgent):
     value_net_fn : function
         Function that returns an instance of a value network (pytorch).
         If None, a default net is used.
-    verbose : int
-        Controls the verbosity, if non zero, progress messages are printed.
 
 
     References
@@ -99,7 +99,6 @@ class AVECPPOAgent(IncrementalAgent):
                  k_epochs=10,
                  policy_net_fn=None,
                  value_net_fn=None,
-                 verbose=1,
                  **kwargs):
         IncrementalAgent.__init__(self, env, **kwargs)
 
@@ -115,7 +114,6 @@ class AVECPPOAgent(IncrementalAgent):
 
         self.state_dim = self.env.observation_space.shape[0]
         self.action_dim = self.env.action_space.n
-        self.verbose = verbose
 
         #
         self.policy_net_fn = policy_net_fn \
@@ -159,10 +157,8 @@ class AVECPPOAgent(IncrementalAgent):
         self._cumul_rewards = np.zeros(self.n_episodes)
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
-        self.writer = PeriodicWriter(self.name, log_every=log_every)
+        self.writer = PeriodicWriter(self.name,
+                                     log_every=5*logger.getEffectiveLevel())
 
     def policy(self, state, **kwargs):
         assert self.cat_policy is not None

--- a/rlberry/agents/cem/cem.py
+++ b/rlberry/agents/cem/cem.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import torch.nn as nn
+import logging
 
 import rlberry.seeding as seeding
 import gym.spaces as spaces
@@ -10,7 +11,7 @@ from rlberry.agents.utils.torch_training import optimizer_factory
 from rlberry.agents.utils.torch_models import default_policy_net_fn
 from rlberry.utils.writers import PeriodicWriter
 
-
+logger = logging.getLogger(__name__)
 # choose device
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -38,8 +39,6 @@ class CEMAgent(Agent):
     policy_net_fn : function
         Function that returns an instance of a policy network (pytorch).
         If None, a default net is used.
-    verbose : int
-        Verbosity level.
     """
 
     name = "CrossEntropyAgent"
@@ -55,7 +54,6 @@ class CEMAgent(Agent):
                  learning_rate=0.01,
                  optimizer_type='ADAM',
                  policy_net_fn=None,
-                 verbose=5,
                  **kwargs):
         Agent.__init__(self, env, **kwargs)
 
@@ -70,7 +68,6 @@ class CEMAgent(Agent):
         self.percentile = percentile
         self.learning_rate = learning_rate
         self.horizon = horizon
-        self.verbose = verbose
 
         # random number generator
         self.rng = seeding.get_rng()
@@ -95,10 +92,8 @@ class CEMAgent(Agent):
         self.memory = CEMMemory(self.batch_size)
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
-        self.writer = PeriodicWriter(self.name, log_every=log_every)
+        self.writer = PeriodicWriter(self.name,
+                                     log_every=5*logger.getEffectiveLevel())
 
     def fit(self, **kwargs):
         self.episode = 0

--- a/rlberry/agents/dqn/abstract.py
+++ b/rlberry/agents/dqn/abstract.py
@@ -1,10 +1,12 @@
 from abc import ABC, abstractmethod
 from gym import spaces
+import logging
 
 from rlberry.agents import Agent
 from rlberry.agents.dqn.exploration import exploration_factory
 from rlberry.agents.utils.memories import ReplayMemory, Transition
 
+logger = logging.getLogger(__name__)
 
 class AbstractDQNAgent(Agent, ABC):
     def __init__(self,
@@ -41,7 +43,7 @@ class AbstractDQNAgent(Agent, ABC):
     def fit(self, **kwargs):
         episode_rewards = []
         for episode in range(self.n_episodes):
-            print("episode", episode)
+            logger.debug(f"episode {episode+1}/{self.n_episodes}")
             done, total_reward = False, 0
             state = self.env.reset()
             ep_time = 0

--- a/rlberry/agents/dqn/abstract.py
+++ b/rlberry/agents/dqn/abstract.py
@@ -8,6 +8,7 @@ from rlberry.agents.utils.memories import ReplayMemory, Transition
 
 logger = logging.getLogger(__name__)
 
+
 class AbstractDQNAgent(Agent, ABC):
     def __init__(self,
                  env,

--- a/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
@@ -115,7 +115,6 @@ class RSKernelUCBVIAgent(Agent):
                  bonus_scale_factor=1.0,
                  beta=0.01,
                  bonus_type="simplified_bernstein",
-                 verbose=1,
                  **kwargs):
         """
         env : Model
@@ -155,8 +154,6 @@ class RSKernelUCBVIAgent(Agent):
             controls the level of exploration.
         beta : double
             Regularization constant.
-        verbose : int
-            Controls the verbosity, if non zero, progress messages are printed.
         bonus_type : string
              Type of exploration bonus. Currently, only "simplified_bernstein"
              is implemented.
@@ -173,7 +170,6 @@ class RSKernelUCBVIAgent(Agent):
         self.min_dist = min_dist
         self.bonus_scale_factor = bonus_scale_factor
         self.beta = beta
-        self.verbose = verbose
         self.bonus_type = bonus_type
 
         # check environment
@@ -260,10 +256,8 @@ class RSKernelUCBVIAgent(Agent):
         self.episode = 0
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
-        self.writer = PeriodicWriter(self.name, log_every=log_every)
+        self.writer = PeriodicWriter(self.name,
+                                     log_every=5*logger.getEffectiveLevel())
 
     def policy(self, state, hh=0, **kwargs):
         assert self.Q_policy is not None

--- a/rlberry/agents/kernel_based/rs_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_ucbvi.py
@@ -61,7 +61,6 @@ class RSUCBVIAgent(Agent):
                  max_repr=1000,
                  bonus_scale_factor=1.0,
                  bonus_type="simplified_bernstein",
-                 verbose=1,
                  **kwargs):
         """
         env : Model
@@ -94,8 +93,6 @@ class RSUCBVIAgent(Agent):
         bonus_scale_factor : double
             Constant by which to multiply the exploration bonus, controls
             the level of exploration.
-        verbose : int
-            Controls the verbosity, if non zero, progress messages are printed.
         bonus_type : string
              Type of exploration bonus. Currently, only "simplified_bernstein"
              is implemented.
@@ -109,7 +106,6 @@ class RSUCBVIAgent(Agent):
         self.lp_metric = lp_metric
         self.min_dist = min_dist
         self.bonus_scale_factor = bonus_scale_factor
-        self.verbose = verbose
         self.bonus_type = bonus_type
 
         # check environment
@@ -198,10 +194,8 @@ class RSUCBVIAgent(Agent):
         self.episode = 0
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
-        self.writer = PeriodicWriter(self.name, log_every=log_every)
+        self.writer = PeriodicWriter(self.name,
+                                     log_every=5*logger.getEffectiveLevel())
 
     def policy(self, state, hh=0, **kwargs):
         assert self.Q_policy is not None

--- a/rlberry/agents/linear/lsvi_ucb.py
+++ b/rlberry/agents/linear/lsvi_ucb.py
@@ -33,7 +33,6 @@ class LSVIUCBAgent(Agent):
                  gamma=0.99,
                  bonus_scale_factor=1.0,
                  reg_factor=0.01,
-                 verbose=1,
                  **kwargs):
         """
         Parameters
@@ -53,8 +52,6 @@ class LSVIUCBAgent(Agent):
             Constant by which to multiply the exploration bonus.
         reg_factor : double
             Linear regression regularization factor.
-        verbose : int
-            Verbosity level.
         """
         Agent.__init__(self, env, **kwargs)
 
@@ -64,7 +61,6 @@ class LSVIUCBAgent(Agent):
         self.gamma = gamma
         self.bonus_scale_factor = bonus_scale_factor
         self.reg_factor = reg_factor
-        self.verbose = verbose
 
         #
         if self.bonus_scale_factor == 0.0:
@@ -128,9 +124,7 @@ class LSVIUCBAgent(Agent):
         for _ in range(self.n_episodes):
             self.run_episode()
 
-            # log
-            if self.verbose > 0:
-                print(self._info_to_print())
+        self.log_info()
 
         self.w_policy = self._run_lsvi(bonus_factor=0.0)
 
@@ -236,12 +230,12 @@ class LSVIUCBAgent(Agent):
     #
     # Logging
     #
-    def _info_to_print(self):
+    def log_info(self):
         episode = self.episode
         avg_over = 10
         reward_per_ep = \
             self._rewards[max(0, episode-avg_over):episode + 1].mean()
-        to_print = "[{}] episode = {}/{} ".format(self.name, episode+1,
+        message = "[{}] episode = {}/{} ".format(self.name, episode+1,
                                                   self.n_episodes) \
             + "| reward/ep = {:0.2f} ".format(reward_per_ep)
-        return to_print
+        logger.debug(message)

--- a/rlberry/agents/ppo/ppo.py
+++ b/rlberry/agents/ppo/ppo.py
@@ -1,6 +1,7 @@
 import numpy as np
 import torch
 import torch.nn as nn
+import logging
 
 import gym.spaces as spaces
 from rlberry.agents import IncrementalAgent
@@ -10,6 +11,7 @@ from rlberry.agents.utils.torch_models import default_policy_net_fn
 from rlberry.agents.utils.torch_models import default_value_net_fn
 from rlberry.utils.writers import PeriodicWriter
 
+logger = logging.getLogger(__name__)
 
 # choose device
 device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
@@ -47,8 +49,6 @@ class PPOAgent(IncrementalAgent):
     value_net_fn : function
         Function that returns an instance of a value network (pytorch).
         If None, a default net is used.
-    verbose : int
-        Controls the verbosity, if non zero, progress messages are printed.
 
 
     References
@@ -78,7 +78,6 @@ class PPOAgent(IncrementalAgent):
                  k_epochs=5,
                  policy_net_fn=None,
                  value_net_fn=None,
-                 verbose=1,
                  **kwargs):
         IncrementalAgent.__init__(self, env, **kwargs)
 
@@ -94,7 +93,6 @@ class PPOAgent(IncrementalAgent):
 
         self.state_dim = self.env.observation_space.shape[0]
         self.action_dim = self.env.action_space.n
-        self.verbose = verbose
 
         #
         self.policy_net_fn = policy_net_fn \
@@ -140,10 +138,8 @@ class PPOAgent(IncrementalAgent):
         self._cumul_rewards = np.zeros(self.n_episodes)
 
         # default writer
-        log_every = 0
-        if self.verbose > 0:
-            log_every = 200/self.verbose
-        self.writer = PeriodicWriter(self.name, log_every=log_every)
+        self.writer = PeriodicWriter(self.name,
+                                     log_every=5*logger.getEffectiveLevel())
 
     def policy(self, state, **kwargs):
         assert self.cat_policy is not None

--- a/rlberry/agents/tests/test_a2c_ppo_avec.py
+++ b/rlberry/agents/tests/test_a2c_ppo_avec.py
@@ -111,8 +111,7 @@ def test_avec_ppo_agent_partial_fit():
                          learning_rate=0.001,
                          eps_clip=0.2,
                          k_epochs=4,
-                         batch_size=1,
-                         verbose=1)
+                         batch_size=1)
     agent._log_interval = 0
 
     agent.partial_fit(0.5)

--- a/rlberry/agents/tests/test_a2c_ppo_avec.py
+++ b/rlberry/agents/tests/test_a2c_ppo_avec.py
@@ -14,8 +14,7 @@ def test_a2c_agent():
                      horizon=horizon,
                      gamma=0.99,
                      learning_rate=0.001,
-                     k_epochs=4,
-                     verbose=0)
+                     k_epochs=4)
     agent._log_interval = 0
     agent.fit()
     agent.policy(env.observation_space.sample())
@@ -31,8 +30,7 @@ def test_a2c_agent_partial_fit():
                      horizon=horizon,
                      gamma=0.99,
                      learning_rate=0.001,
-                     k_epochs=4,
-                     verbose=1)
+                     k_epochs=4)
     agent._log_interval = 0
 
     agent.partial_fit(0.5)
@@ -54,8 +52,7 @@ def test_ppo_agent():
                      gamma=0.99,
                      learning_rate=0.001,
                      eps_clip=0.2,
-                     k_epochs=4,
-                     verbose=0)
+                     k_epochs=4)
     agent._log_interval = 0
     agent.fit()
     agent.policy(env.observation_space.sample())
@@ -73,8 +70,7 @@ def test_ppo_agent_partial_fit():
                      learning_rate=0.001,
                      eps_clip=0.2,
                      k_epochs=4,
-                     batch_size=1,
-                     verbose=1)
+                     batch_size=1)
     agent._log_interval = 0
 
     agent.partial_fit(0.5)
@@ -97,8 +93,7 @@ def test_avec_ppo_agent():
                          learning_rate=0.001,
                          eps_clip=0.2,
                          k_epochs=4,
-                         batch_size=1,
-                         verbose=1)
+                         batch_size=1)
     agent._log_interval = 0
     agent.fit()
     agent.policy(env.observation_space.sample())

--- a/rlberry/agents/tests/test_cem.py
+++ b/rlberry/agents/tests/test_cem.py
@@ -15,8 +15,7 @@ def test_cem_agent():
                      gamma,
                      batch_size,
                      percentile=70,
-                     learning_rate=0.01,
-                     verbose=1)
+                     learning_rate=0.01)
     agent._log_interval = 0
     agent.fit()
     agent.policy(env.observation_space.sample())

--- a/rlberry/agents/tests/test_kernel_based.py
+++ b/rlberry/agents/tests/test_kernel_based.py
@@ -26,8 +26,7 @@ def test_rs_kernel_ucbvi(kernel_type):
                                 min_dist=0.2,
                                 bandwidth=0.05,
                                 beta=1.0,
-                                kernel_type=kernel_type,
-                                verbose=1)
+                                kernel_type=kernel_type)
         agent._log_interval = 0
         agent.fit()
         agent.policy(env.observation_space.sample())
@@ -39,8 +38,7 @@ def test_rs_ucbvi():
                          n_episodes=5,
                          gamma=0.99,
                          horizon=30,
-                         bonus_scale_factor=0.1,
-                         verbose=1)
+                         bonus_scale_factor=0.1)
     agent._log_interval = 0
     agent.fit()
     agent.policy(env.observation_space.sample())

--- a/rlberry/colab_utils/display_setup.py
+++ b/rlberry/colab_utils/display_setup.py
@@ -21,7 +21,6 @@ def show_video(filename=None, directory='./videos'):
     else:
         files = Path(directory).glob("*.mp4")
     for mp4 in files:
-        print(mp4)
         video_b64 = base64.b64encode(mp4.read_bytes())
         html.append('''<video alt="{}" autoplay
                       loop controls style="height: 400px;">

--- a/rlberry/envs/benchmarks/ball_exploration/pball.py
+++ b/rlberry/envs/benchmarks/ball_exploration/pball.py
@@ -1,8 +1,11 @@
 import numpy as np
+import logging
 
 import rlberry.spaces as spaces
 from rlberry.envs.interface import Model
 from rlberry.rendering import Scene, GeometricPrimitive, RenderInterface2D
+
+logger = logging.getLogger(__name__)
 
 
 def projection_to_pball(x, p):
@@ -118,7 +121,7 @@ class PBall(Model):
 
         assert p >= 1, "PBall requires p>=1"
         if p not in [2, np.inf]:
-            print("WARNING: for p!=2 or p!=np.inf, PBall \
+            logger.warning("For p!=2 or p!=np.inf, PBall \
 does not make true projections onto the lp ball.")
         self.p = p
         self.d, self.dp = B.shape  # d and d'

--- a/rlberry/envs/finite/finite_mdp.py
+++ b/rlberry/envs/finite/finite_mdp.py
@@ -1,7 +1,10 @@
 import numpy as np
+import logging
 
 import rlberry.spaces as spaces
 from rlberry.envs.interface import Model
+
+logger = logging.getLogger(__name__)
 
 
 class FiniteMDP(Model):
@@ -125,20 +128,20 @@ class FiniteMDP(Model):
         """
         return self.R[state, action]
 
-    def print(self):
+    def log(self):
         """
         Print the structure of the MDP.
         """
         indent = '    '
         for s in self._states:
-            print(("State %d" + indent) % s)
+            logger.info(f"State {s} {indent}")
             for a in self._actions:
-                print(indent + "Action ", a)
+                logger.info(f"{indent} Action {a}")
                 for ss in self._states:
                     if self.P[s, a, ss] > 0.0:
-                        print(2 * indent + 'transition to %d with prob %0.2f'
-                              % (ss, self.P[s, a, ss]))
-            print("~~~~~~~~~~~~~~~~~~~~")
+                        logger.info(f'{2 * indent} transition to {ss} '
+                                    f'with prob {self.P[s, a, ss]: .2f}')
+            logger.info("~~~~~~~~~~~~~~~~~~~~")
 
 
 # if __name__ == '__main__':

--- a/rlberry/envs/finite/gridworld.py
+++ b/rlberry/envs/finite/gridworld.py
@@ -1,8 +1,11 @@
 import numpy as np
+import logging
 
 from rlberry.envs.finite import FiniteMDP
 from rlberry.rendering import Scene, GeometricPrimitive, RenderInterface2D
 from rlberry.rendering.common_shapes import circle_shape
+
+logger = logging.getLogger(__name__)
 
 
 class GridWorld(RenderInterface2D, FiniteMDP):
@@ -268,21 +271,21 @@ class GridWorld(RenderInterface2D, FiniteMDP):
                 grid_values_ascii += 4 * ' ' \
                     + ' '.join([str(jj).zfill(2).ljust(9) for jj
                                 in range(self.ncols)])
-        print(grid_values_ascii)
+        logger.info(grid_values_ascii)
 
     def print_transition_at(self, row, col, action):
         s_idx = self.coord2index[(row, col)]
         if s_idx < 0:
-            print("wall!")
+            logger.info("wall!")
             return
         a_idx = self.a_str2idx[action]
         for next_s_idx, prob in enumerate(self.P[s_idx, a_idx]):
             if prob > 0:
-                print("to (%d, %d) with prob %f" %
+                logger.info("to (%d, %d) with prob %f" %
                       (self.index2coord[next_s_idx] + (prob,)))
 
     def render_ascii(self):
-        print(self._build_ascii())
+        logger.info(self._build_ascii())
 
     def step(self, action):
         assert self.action_space.contains(action), "Invalid action!"

--- a/rlberry/envs/tests/test_instantiation.py
+++ b/rlberry/envs/tests/test_instantiation.py
@@ -52,7 +52,7 @@ def test_rendering_calls(ModelClass):
 def test_gridworld_aux_functions():
     env = GridWorld(nrows=5, ncols=5, walls=((1, 1),),
                     reward_at={(4, 4): 1, (4, 3): -1})
-    env.print()  # from FiniteMDP
+    env.log()  # from FiniteMDP
     env.render_ascii()  # from GridWorld
     vals = np.ones(env.observation_space.n)
     env.display_values(vals)

--- a/rlberry/rendering/opengl_render2d.py
+++ b/rlberry/rendering/opengl_render2d.py
@@ -4,8 +4,10 @@ OpenGL code for 2D rendering, using pygame.
 
 import numpy as np
 from os import environ
+import logging
 from rlberry.rendering import Scene
 
+logger = logging.getLogger(__name__)
 environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 
 _IMPORT_SUCESSFUL = True
@@ -137,7 +139,7 @@ class OpenGLRender2D:
         elif shape.type == "QUAD_STRIP":
             glBegin(GL_QUAD_STRIP)
         else:
-            print("Invalid type for geometric primitive!")
+            logger.error("Invalid type for geometric primitive!")
             raise NameError
 
         # set color
@@ -176,7 +178,7 @@ class OpenGLRender2D:
                     pg.quit()
                     return
         else:
-            print("Error: not possible to render the environment, \
+            logger.error("Not possible to render the environment, \
 pygame or pyopengl not installed.")
 
     def get_video_data(self):
@@ -216,6 +218,6 @@ pygame or pyopengl not installed.")
             pg.quit()
             return video_data
         else:
-            print("Error: not possible to render the environment, \
+            logger.error("Not possible to render the environment, \
 pygame or pyopengl not installed.")
             return []

--- a/rlberry/rendering/pygame_render2d.py
+++ b/rlberry/rendering/pygame_render2d.py
@@ -4,7 +4,10 @@ Code for 2D rendering, using pygame (without OpenGL)
 
 import numpy as np
 from os import environ
+import logging
 from rlberry.rendering import Scene
+
+logger = logging.getLogger(__name__)
 
 environ['PYGAME_HIDE_SUPPORT_PROMPT'] = '1'
 
@@ -145,7 +148,7 @@ class PyGameRender2D:
                     pg.quit()
                     return
         else:
-            print("Error: not possible to render the environment, \
+            logger.error("Not possible to render the environment, \
 pygame or pyopengl not installed.")
 
     def get_video_data(self):
@@ -184,7 +187,7 @@ pygame or pyopengl not installed.")
             pg.quit()
             return video_data
         else:
-            print("Error: not possible to render the environment, pygame \
+            logger.error("Not possible to render the environment, pygame \
 or pyopengl not installed.")
             return []
 

--- a/rlberry/rendering/render_interface.py
+++ b/rlberry/rendering/render_interface.py
@@ -2,11 +2,14 @@
 Interface that allows 2D rendering.
 """
 
+import logging
 from abc import ABC, abstractmethod
 
 from rlberry.rendering.opengl_render2d import OpenGLRender2D
 from rlberry.rendering.pygame_render2d import PyGameRender2D
 from rlberry.rendering.utils import video_write
+
+logger = logging.getLogger(__name__)
 
 
 class RenderInterface(ABC):
@@ -112,7 +115,7 @@ class RenderInterface2D(RenderInterface):
             background, data = self._get_background_and_scenes()
 
             if len(data) == 0:
-                print("No data to render.")
+                logger.info("No data to render.")
                 return
 
             # render
@@ -126,7 +129,7 @@ class RenderInterface2D(RenderInterface):
             renderer.run_graphics(self._debug_mode)
             return 0
         else:
-            print("Rendering not enabled for the environment.")
+            logger.info("Rendering not enabled for the environment.")
             return 1
 
     def save_video(self, filename, framerate=25, **kwargs):
@@ -135,7 +138,7 @@ class RenderInterface2D(RenderInterface):
         background, data = self._get_background_and_scenes()
 
         if len(data) == 0:
-            print("No data to save.")
+            logger.info("No data to save.")
             return
 
         # get video data from renderer

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import gym
 
 
-def configure_logging(level: str = "INFO", file_path: Path = None, file_level: str = "DEBUG") -> None:
+def configure_logging(level: str = "INFO",
+                      file_path: Path = None,
+                      file_level: str = "DEBUG") -> None:
     """
     Set the logging configuration
 

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -1,0 +1,62 @@
+import logging.config
+from pathlib import Path
+import gym
+
+
+def configure_logging(level: str = "INFO", file_path: Path = None, file_level: str = "DEBUG") -> None:
+    """
+    Set the logging configuration
+
+    This default config can be further edited to only enable logging
+    in specific modules, by providing the name of its logger.
+
+    Parameters
+    ----------
+    level
+        Level of verbosity for the default (console) handler
+    file_path
+        Path to a log file
+    file_level
+        Level of verbosity for the file handler
+    """
+    config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {
+                "format": "[%(levelname)s] %(message)s "
+            },
+            "detailed": {
+                "format": "[%(name)s:%(levelname)s] %(message)s "
+            }
+        },
+        "handlers": {
+            "default": {
+                "level": level,
+                "formatter": "standard",
+                "class": "logging.StreamHandler"
+            }
+        },
+        "loggers": {
+            "": {
+                "handlers": [
+                    "default"
+                ],
+                "level": "DEBUG",
+                "propagate": True
+            }
+        }
+    }
+    if file_path:
+        config["handlers"][file_path.name] = {
+            "class": "logging.FileHandler",
+            "filename": file_path,
+            "level": file_level,
+            "formatter": "detailed",
+            "mode": 'w'
+        }
+        config["loggers"][""]["handlers"].append(file_path.name)
+    logging.config.dictConfig(config)
+    gym.logger.set_level(logging.getLevelName(level))
+    numba_logger = logging.getLogger('numba')
+    numba_logger.setLevel(logging.WARNING)

--- a/rlberry/utils/torch.py
+++ b/rlberry/utils/torch.py
@@ -4,6 +4,9 @@ import shutil
 from subprocess import check_output, run, PIPE
 import numpy as np
 import torch
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def get_gpu_memory_map():
@@ -24,8 +27,8 @@ cannot select device with most least memory used.")
 
     memory_map = get_gpu_memory_map()
     device_id = np.argmin(memory_map)
-    print("Choosing GPU device: {}, memory used: {}"
-          .format(device_id, memory_map[device_id]))
+    logger.info(f"Choosing GPU device: {device_id}, "
+                f"memory used: {memory_map[device_id]}")
     return torch.device("cuda:{}".format(device_id))
 
 
@@ -36,8 +39,8 @@ def choose_device(preferred_device, default_device="cpu"):
         torch.zeros((1,), device=preferred_device)  # Test availability
         return preferred_device
     except (RuntimeError, AssertionError):
-        print("Preferred device {} unavailable, switching to default {}"
-              .format(preferred_device, default_device))
+        logger.info(f"Preferred device {preferred_device} unavailable, "
+                    f"switching to default {default_device}")
         return default_device
 
 

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -1,4 +1,7 @@
 import time
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class PeriodicWriter:
@@ -64,7 +67,7 @@ class PeriodicWriter:
         logs_per_ms = self.log_every / max(1, time_elapsed)
         message += " | freq = {:0.3f} logs/ms".format(logs_per_ms)
 
-        print(message)
+        logger.debug(message)
 
     def __getattr__(self, attr):
         """


### PR DESCRIPTION
Use python's logging package within rlberry.

- `logger.info()`, `logger.warning()`, `logger.error()` should now be used inside the rlberry package, rather than `print()`.
- The desired level of verbosity can be chosen by calling the `configure_logging`. An option allows to print logs in a file, with a potentially different level of verbosity. More sophisticated configurations could also be used (e.g. all modules on info, only one agent on debug).
- `print()` statements can still be used outside of rlberry, e.g. in scripts and notebooks

Fixes #16 