### PR TITLE
Adding seeding in ppo.py to enforce seeding (seeding.set_global_seed not enough)

### DIFF
--- a/rlberry/agents/ppo/ppo.py
+++ b/rlberry/agents/ppo/ppo.py
@@ -149,6 +149,7 @@ class PPOAgent(IncrementalAgent):
         assert isinstance(self.env.action_space, spaces.Discrete)
 
         self.cat_policy = None  # categorical policy function
+        self.rng = seeding.get_rng()
 
         # initialize
         self.reset()
@@ -300,8 +301,7 @@ class PPOAgent(IncrementalAgent):
         for _ in range(self.k_epochs):
 
             # shuffle samples
-            np_random = seeding.get_rng()
-            rd_indices = np_random.choice(n_samples, size=n_samples, replace=False)
+            rd_indices = self.rng.choice(n_samples, size=n_samples, replace=False)
             shuffled_states = full_old_states[rd_indices]
             shuffled_actions = full_old_actions[rd_indices]
             shuffled_logprobs = full_old_logprobs[rd_indices]

--- a/rlberry/agents/ppo/ppo.py
+++ b/rlberry/agents/ppo/ppo.py
@@ -12,6 +12,7 @@ from rlberry.agents.utils.torch_models import default_value_net_fn
 from rlberry.utils.torch import choose_device
 from rlberry.utils.writers import PeriodicWriter
 from rlberry.wrappers.uncertainty_estimator_wrapper import UncertaintyEstimatorWrapper
+from rlberry.seeding import seeding
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +300,8 @@ class PPOAgent(IncrementalAgent):
         for _ in range(self.k_epochs):
 
             # shuffle samples
-            rd_indices = np.random.choice(n_samples, size=n_samples, replace=False)
+            np_random = seeding.get_rng()
+            rd_indices = np_random.choice(n_samples, size=n_samples, replace=False)
             shuffled_states = full_old_states[rd_indices]
             shuffled_actions = full_old_actions[rd_indices]
             shuffled_logprobs = full_old_logprobs[rd_indices]


### PR DESCRIPTION
Hello,

Just a very short PR because I would like to see with you what you think is the best way to seed a call to `np.random.choice` inside PPO.

I'm using `from rlberry.seeding import seeding` in `agents/ppo/ppos.py`.

In fact, I wonder why this is not already taken care of by `seeding.set_global_seed(1223)` in `examples/demo_ppo.py`. If you try running `examples/demo_ppo.py` without the change of this PR, `rd_indices` L304 will produce different integers each time (hence I label the PR as Bug, but I may be wrong here).

What do you think?