### PR TITLE
Setup of arbitrary entries in replay buffer in jax agents

### DIFF
--- a/rlberry/agents/jax/utils/replay_buffer.py
+++ b/rlberry/agents/jax/utils/replay_buffer.py
@@ -72,6 +72,7 @@ class ReplayBuffer:
 
     TODO:
     * Sampling from different tables (priotirized, uniform etc.)
+    * Update priorities.
 
     """
     def __init__(

--- a/rlberry/agents/jax/utils/replay_buffer.py
+++ b/rlberry/agents/jax/utils/replay_buffer.py
@@ -5,9 +5,7 @@ Notes
 * For priority updates, see https://github.com/deepmind/reverb/issues/28
 """
 
-import gym
 import logging
-import numpy as np
 import tensorflow as tf
 
 logger = logging.getLogger(__name__)
@@ -30,11 +28,12 @@ except ImportError as ex:
 
 class ChunkWriter:
     """Wrapper for reverb's TrajectoryWriter"""
-    def __init__(self, reverb_client, chunk_size):
+    def __init__(self, reverb_client, chunk_size, entries):
         self.writer = None
         self.chunk_size = chunk_size
         self.client = reverb_client
         self.total_items = 0
+        self.entries = set(entries)
 
     def __enter__(self):
         self.writer = self.client.trajectory_writer(num_keep_alive_refs=self.chunk_size)
@@ -54,6 +53,10 @@ class ChunkWriter:
         if self.writer.episode_steps >= self.chunk_size:
             trajectory = dict()
             for key in self.writer.history:
+                if key not in self.entries:
+                    raise RuntimeError(
+                        'Cannot add to replay buffer an item that'
+                        f' was not setup with setup_entry() method of ReplayBuffer: {key}')
                 trajectory[key] = self.writer.history[key][-self.chunk_size:]
             self.writer.create_item(
                 table='replay_buffer',
@@ -73,7 +76,6 @@ class ReplayBuffer:
     """
     def __init__(
         self,
-        env: gym.Env,
         batch_size: int,
         chunk_size: int,
         max_replay_size: int,
@@ -85,32 +87,19 @@ class ReplayBuffer:
         self._chunk_size = chunk_size
         self._max_replay_size = max_replay_size
 
-        # define specs
-        # TODO: generalize. Observation is taken from reset() because gym is
-        # mixing things up (returning double instead of float)
-        sample_obs = env.reset()
-        try:
-            self._observation_spec = tf.TensorSpec(
-                sample_obs.shape, sample_obs.dtype)
-        except AttributeError:   # in case sample_obs has no .shape attribute
-            self._observation_spec = tf.TensorSpec(
-                env.observation_space.shape, env.observation_space.dtype)
-        self._action_spec = tf.TensorSpec(
-            env.action_space.shape, env.action_space.dtype)
-
         self._reverb_server = None
         self._reverb_client = None
         self._reverb_dataset = None
         self._batched_dataset = None
         self._chunk_writer = None
-        self._init_replay_buffer()
+        self._signature = dict()
 
     @property
     def dataset(self):
         return self._batched_dataset
 
     def get_writer(self):
-        self._chunk_writer = ChunkWriter(self._reverb_client, self._chunk_size)
+        self._chunk_writer = ChunkWriter(self._reverb_client, self._chunk_size, list(self._signature.keys()))
         return self._chunk_writer
 
     def sample(self):
@@ -120,7 +109,29 @@ class ReplayBuffer:
             return None
         return next(self.dataset)
 
-    def _init_replay_buffer(self):
+    def setup_entry(self, name, shape, dtype):
+        """
+        Setup new entry in the replay buffer.
+
+        Parameters
+        ----------
+        name : str
+            Entry name.
+        shape :
+            Shape of the data. Can be nested.
+        dtype :
+            Type of the data. Can be nested.
+        """
+        if name in self._signature:
+            raise ValueError(f'Entry {name} already added to the replay buffer.')
+
+        self._signature[name] = tf.TensorSpec(
+            shape=[self._chunk_size, *shape],
+            dtype=dtype,
+        )
+
+    def build(self):
+        """Creates reverb server, client and dataset."""
         self._reverb_server = reverb.Server(
             tables=[
                 reverb.Table(
@@ -129,23 +140,7 @@ class ReplayBuffer:
                     remover=reverb.selectors.Fifo(),
                     max_size=self._max_replay_size,
                     rate_limiter=reverb.rate_limiters.MinSize(1),
-                    signature={
-                        'actions': tf.TensorSpec(
-                            shape=[self._chunk_size, *self._action_spec.shape],
-                            dtype=self._action_spec.dtype),
-                        'observations': tf.TensorSpec(
-                            shape=[self._chunk_size, *self._observation_spec.shape],
-                            dtype=self._observation_spec.dtype),
-                        'rewards': tf.TensorSpec(
-                            shape=[self._chunk_size, ],
-                            dtype=np.float32),
-                        'discounts': tf.TensorSpec(
-                            shape=[self._chunk_size, ],
-                            dtype=np.float32),
-                        'next_observations': tf.TensorSpec(
-                            shape=[self._chunk_size, *self._observation_spec.shape],
-                            dtype=self._observation_spec.dtype),
-                    },
+                    signature=self._signature,
                 ),
             ],
             port=None

--- a/scripts/conda_env_setup.sh
+++ b/scripts/conda_env_setup.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cd $CONDA_PREFIX
+mkdir -p ./etc/conda/activate.d
+mkdir -p ./etc/conda/deactivate.d
+touch ./etc/conda/activate.d/env_vars.sh
+touch ./etc/conda/deactivate.d/env_vars.sh
+
+echo '#!/bin/sh' > ./etc/conda/activate.d/env_vars.sh
+echo  >> ./etc/conda/activate.d/env_vars.sh
+echo "export LD_LIBRARY_PATH=$CONDA_PREFIX/lib" >> ./etc/conda/activate.d/env_vars.sh
+
+echo '#!/bin/sh' > ./etc/conda/deactivate.d/env_vars.sh
+echo >> ./etc/conda/deactivate.d/env_vars.sh
+echo "unset LD_LIBRARY_PATH" >> ./etc/conda/deactivate.d/env_vars.sh
+
+echo "Contents of $CONDA_PREFIX/etc/conda/activate.d/env_vars.sh:"
+cat ./etc/conda/activate.d/env_vars.sh
+echo ""
+
+echo "Contents of $CONDA_PREFIX/etc/conda/deactivate.d/env_vars.sh:"
+cat ./etc/conda/deactivate.d/env_vars.sh
+echo ""


### PR DESCRIPTION
The data added to the replay buffer was limited to observations, actions, rewards, discounts and next observations.

With this PR, we can do the following to handle arbitrary entries:

```
from rlberry.agents.jax.utils.replay_buffer import ReplayBuffer

replay_buffer = ReplayBuffer(batch_size, chunk_size, max_replay_size)
replay_buffer.setup_entry('actions', action_shape, action_dtype)
replay_buffer.setup_entry('observations', obs_shape, obs_dtype)
replay_buffer.setup_entry('other_data', other_data_shape, other_data_dtype)

```