### PR TITLE
fix(agents): initialization issue of UCBVI

### DIFF
--- a/rlberry/agents/dynprog/utils.py
+++ b/rlberry/agents/dynprog/utils.py
@@ -49,11 +49,15 @@ def backward_induction(R, P, horizon, gamma=1.0, vmax=np.inf):
                 V[hh, ss] = vmax
     return Q, V
 
+
 @numba_jit
-def backward_induction_reward_sd(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):
+def backward_induction_reward_sd(Q, V, R, P, gamma=1.0, vmax=np.inf):
     """
     Backward induction to compute Q and V functions in
     the finite horizon setting.
+
+    Assumes R is stage-dependent, but P is stage-independent.
+
     Takes as input the arrays where to store Q and V.
 
     Parameters
@@ -77,6 +81,7 @@ def backward_induction_reward_sd(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):
         default = np.inf
     """
     H, S, A = R.shape
+    horizon = H
     for hh in range(horizon - 1, -1, -1):
         for ss in range(S):
             max_q = -np.inf
@@ -94,6 +99,7 @@ def backward_induction_reward_sd(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):
             V[hh, ss] = max_q
             if V[hh, ss] > vmax:
                 V[hh, ss] = vmax
+
 
 @numba_jit
 def backward_induction_in_place(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):

--- a/rlberry/agents/dynprog/utils.py
+++ b/rlberry/agents/dynprog/utils.py
@@ -49,6 +49,51 @@ def backward_induction(R, P, horizon, gamma=1.0, vmax=np.inf):
                 V[hh, ss] = vmax
     return Q, V
 
+@numba_jit
+def backward_induction_reward_sd(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):
+    """
+    Backward induction to compute Q and V functions in
+    the finite horizon setting.
+    Takes as input the arrays where to store Q and V.
+
+    Parameters
+    ----------
+    Q:  numpy.ndarray
+        array of shape (horizon, S, A) where to store the Q function
+    V:  numpy.ndarray
+        array of shape (horizon, S) where to store the V function
+    R : numpy.ndarray
+        array of shape (horizon, S, A) contaning the rewards, where S is the number
+        of states and A is the number of actions
+    P : numpy.ndarray
+        array of shape (S, A, S) such that P[s,a,ns] is the probability of
+        arriving at ns by taking action a in state s.
+    horizon : int
+        problem horizon
+    gamma : double
+        discount factor, default = 1.0
+    vmax : double
+        maximum possible value in V
+        default = np.inf
+    """
+    H, S, A = R.shape
+    for hh in range(horizon - 1, -1, -1):
+        for ss in range(S):
+            max_q = -np.inf
+            for aa in range(A):
+                q_aa = R[hh, ss, aa]
+                if hh < horizon - 1:
+                    # not using .dot instead of loop to avoid scipy dependency
+                    # (numba seems to require scipy for linear algebra
+                    #  operations in numpy)
+                    for ns in range(S):
+                        q_aa += gamma * P[ss, aa, ns] * V[hh + 1, ns]
+                if q_aa > max_q:
+                    max_q = q_aa
+                Q[hh, ss, aa] = q_aa
+            V[hh, ss] = max_q
+            if V[hh, ss] > vmax:
+                V[hh, ss] = vmax
 
 @numba_jit
 def backward_induction_in_place(Q, V, R, P, horizon, gamma=1.0, vmax=np.inf):

--- a/rlberry/agents/tests/test_dynprog.py
+++ b/rlberry/agents/tests/test_dynprog.py
@@ -6,6 +6,7 @@ from rlberry.agents.dynprog import ValueIterationAgent
 from rlberry.agents.dynprog.utils import backward_induction
 from rlberry.agents.dynprog.utils import backward_induction_in_place
 from rlberry.agents.dynprog.utils import backward_induction_sd
+from rlberry.agents.dynprog.utils import backward_induction_reward_sd
 from rlberry.agents.dynprog.utils import bellman_operator
 from rlberry.agents.dynprog.utils import value_iteration
 from rlberry.envs.finite import FiniteMDP
@@ -137,13 +138,20 @@ def test_backward_induction_sd(horizon, S, A):
         # run backward induction in stationary MDP
         Qstat, Vstat = backward_induction(Rstat, Pstat, horizon)
 
-        # run backward induction in statage-dependent MDP
+        # run backward induction in stage-dependent MDP
         Q = np.zeros((horizon, S, A))
         V = np.zeros((horizon, S))
         backward_induction_sd(Q, V, R, P)
 
+        # run backward induction with stage-dependent rewards
+        Q2 = np.zeros((horizon, S, A))
+        V2 = np.zeros((horizon, S))
+        backward_induction_reward_sd(Q2, V2, R, Pstat)
+
         assert np.array_equal(Q, Qstat)
         assert np.array_equal(V, Vstat)
+        assert np.array_equal(Q2, Qstat)
+        assert np.array_equal(V2, Vstat)
 
 
 @pytest.mark.parametrize("horizon, gamma, S, A",

--- a/rlberry/agents/ucbvi/ucbvi.py
+++ b/rlberry/agents/ucbvi/ucbvi.py
@@ -3,7 +3,7 @@ import numpy as np
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
-from rlberry.agents.ucbvi.utils import update_value_and_get_action, update_value_and_get_action_sd
+from rlberry.agents.ucbvi.utils import update_value_and_get_action, update_value_and_get_action_sd, backward_induction_reward_sd
 from rlberry.exploration_tools.discrete_counter import DiscreteCounter
 from rlberry.agents.dynprog.utils import backward_induction_sd
 from rlberry.agents.dynprog.utils import backward_induction_in_place
@@ -117,10 +117,10 @@ class UCBVIAgent(AgentWithSimplePolicy):
             shape_hsa = (S, A)
             shape_hsas = (S, A, S)
 
-        # (s, a) visit counter
+        # visit counter
         self.N_sa = np.zeros(shape_hsa)
-        # (s, a) bonus
-        self.B_sa = np.ones(shape_hsa)
+        # bonus
+        self.B_sa = np.zeros((H, S, A))
 
         # MDP estimator
         self.R_hat = np.zeros(shape_hsa)
@@ -134,13 +134,9 @@ class UCBVIAgent(AgentWithSimplePolicy):
         self.Q_policy = np.zeros((H, S, A))
 
         # Init V and bonus
-        if not self.stage_dependent:
-            self.B_sa *= self.v_max[0]
-            self.V *= self.v_max[0]
-        else:
-            for hh in range(self.horizon):
-                self.B_sa[hh, :, :] = self.v_max[hh]
-                self.V[hh, :] = self.v_max[hh]
+        for hh in range(self.horizon):
+            self.B_sa[hh, :, :] = self.v_max[hh]
+            self.V[hh, :] = self.v_max[hh]
 
         # ep counter
         self.episode = 0
@@ -220,7 +216,7 @@ class UCBVIAgent(AgentWithSimplePolicy):
             self.P_hat[state, action, :] = (1.0 - 1.0 / nn) * prev_p
             self.P_hat[state, action, next_state] += 1.0 / nn
 
-            self.B_sa[state, action] = self._compute_bonus(nn, 0)
+            self.B_sa[hh, state, action] = self._compute_bonus(nn, hh)
 
     def _run_episode(self):
         # interact for H steps
@@ -253,7 +249,7 @@ class UCBVIAgent(AgentWithSimplePolicy):
                     self.gamma,
                     self.v_max[0])
             else:
-                backward_induction_in_place(
+                backward_induction_reward_sd(
                     self.Q,
                     self.V,
                     self.R_hat + self.B_sa,

--- a/rlberry/agents/ucbvi/ucbvi.py
+++ b/rlberry/agents/ucbvi/ucbvi.py
@@ -254,7 +254,6 @@ class UCBVIAgent(AgentWithSimplePolicy):
                     self.V,
                     self.R_hat + self.B_sa,
                     self.P_hat,
-                    self.horizon,
                     self.gamma,
                     self.v_max[0])
 

--- a/rlberry/agents/ucbvi/ucbvi.py
+++ b/rlberry/agents/ucbvi/ucbvi.py
@@ -3,9 +3,9 @@ import numpy as np
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
-from rlberry.agents.ucbvi.utils import update_value_and_get_action, update_value_and_get_action_sd, backward_induction_reward_sd
+from rlberry.agents.ucbvi.utils import update_value_and_get_action, update_value_and_get_action_sd
 from rlberry.exploration_tools.discrete_counter import DiscreteCounter
-from rlberry.agents.dynprog.utils import backward_induction_sd
+from rlberry.agents.dynprog.utils import backward_induction_sd, backward_induction_reward_sd
 from rlberry.agents.dynprog.utils import backward_induction_in_place
 
 logger = logging.getLogger(__name__)

--- a/rlberry/agents/ucbvi/utils.py
+++ b/rlberry/agents/ucbvi/utils.py
@@ -20,7 +20,7 @@ def update_value_and_get_action(state,
     P_hat : np.ndarray
         shape (S, A, S)
     B_sa : np.ndarray
-        shape (S, A)
+        shape (H, S, A)
     gamma : double
     v_max : np.ndarray
         shape (H,)
@@ -32,7 +32,7 @@ def update_value_and_get_action(state,
     previous_value = V[hh, state]
 
     for aa in range(A):
-        q_aa = R_hat[state, aa] + B_sa[state, aa]
+        q_aa = R_hat[state, aa] + B_sa[hh,state, aa]
 
         if hh < H - 1:
             for sn in range(S):


### PR DESCRIPTION
Fix the initialization of the value and bonus of UCBVI to v_max[hh] instead of v_max[0] in the stage independent case.