### PR TITLE
feat(agent): add RLSVI algorithm plus option for PSLR

### DIFF
--- a/rlberry/agents/rlsvi/__init__.py
+++ b/rlberry/agents/rlsvi/__init__.py
@@ -1,0 +1,1 @@
+from .rlsvi import RLSVIAgent

--- a/rlberry/agents/tests/test_psrl.py
+++ b/rlberry/agents/tests/test_psrl.py
@@ -3,17 +3,19 @@ from rlberry.agents.psrl import PSRLAgent
 from rlberry.envs.finite import GridWorld
 
 
-@pytest.mark.parametrize("gamma, stage_dependent, bernoullized_reward",
-                         [
-                             (1.0, True, True),
-                             (1.0, True, False),
-                             (1.0, False, True),
-                             (1.0, False, False),
-                             (0.9, True, True),
-                             (0.9, True, False),
-                             (0.9, False, True),
-                             (0.9, False, False),
-                         ])
+@pytest.mark.parametrize(
+    "gamma, stage_dependent, bernoullized_reward",
+    [
+        (1.0, True, True),
+        (1.0, True, False),
+        (1.0, False, True),
+        (1.0, False, False),
+        (0.9, True, True),
+        (0.9, True, False),
+        (0.9, False, True),
+        (0.9, False, False),
+    ],
+)
 def test_ucbvi(gamma, stage_dependent, bernoullized_reward):
     env = GridWorld(walls=(), nrows=5, ncols=5)
     agent = PSRLAgent(
@@ -21,6 +23,7 @@ def test_ucbvi(gamma, stage_dependent, bernoullized_reward):
         horizon=11,
         bernoullized_reward=bernoullized_reward,
         stage_dependent=stage_dependent,
-        gamma=gamma)
+        gamma=gamma,
+    )
     agent.fit(budget=50)
     agent.policy(env.observation_space.sample())

--- a/rlberry/agents/tests/test_psrl.py
+++ b/rlberry/agents/tests/test_psrl.py
@@ -3,18 +3,23 @@ from rlberry.agents.psrl import PSRLAgent
 from rlberry.envs.finite import GridWorld
 
 
-@pytest.mark.parametrize("gamma, stage_dependent",
+@pytest.mark.parametrize("gamma, stage_dependent, bernoullized_reward",
                          [
-                             (1.0, True),
-                             (1.0, False),
-                             (0.9, True),
-                             (0.9, False),
+                             (1.0, True, True),
+                             (1.0, True, False),
+                             (1.0, False, True),
+                             (1.0, False, False),
+                             (0.9, True, True),
+                             (0.9, True, False),
+                             (0.9, False, True),
+                             (0.9, False, False),
                          ])
-def test_ucbvi(gamma, stage_dependent):
+def test_ucbvi(gamma, stage_dependent, bernoullized_reward):
     env = GridWorld(walls=(), nrows=5, ncols=5)
     agent = PSRLAgent(
         env,
         horizon=11,
+        bernoullized_reward=bernoullized_reward,
         stage_dependent=stage_dependent,
         gamma=gamma)
     agent.fit(budget=50)

--- a/rlberry/agents/tests/test_rlsvi.py
+++ b/rlberry/agents/tests/test_rlsvi.py
@@ -1,0 +1,20 @@
+import pytest
+from rlberry.agents.rlsvi import RLSVIAgent
+from rlberry.envs.finite import GridWorld
+
+
+@pytest.mark.parametrize("gamma, stage_dependent",
+                         [
+                             (1.0, True),
+                             (1.0, False),
+                             (0.9, True),
+                             (0.9, False),
+                         ])
+def test_rlsvi(gamma, stage_dependent):
+    env = GridWorld(walls=(), nrows=5, ncols=5)
+    agent = RLSVIAgent(env,
+                       horizon=11,
+                       stage_dependent=stage_dependent,
+                       gamma=gamma)
+    agent.fit(budget=50)
+    agent.policy(env.observation_space.sample())

--- a/rlberry/agents/tests/test_rlsvi.py
+++ b/rlberry/agents/tests/test_rlsvi.py
@@ -3,18 +3,17 @@ from rlberry.agents.rlsvi import RLSVIAgent
 from rlberry.envs.finite import GridWorld
 
 
-@pytest.mark.parametrize("gamma, stage_dependent",
-                         [
-                             (1.0, True),
-                             (1.0, False),
-                             (0.9, True),
-                             (0.9, False),
-                         ])
+@pytest.mark.parametrize(
+    "gamma, stage_dependent",
+    [
+        (1.0, True),
+        (1.0, False),
+        (0.9, True),
+        (0.9, False),
+    ],
+)
 def test_rlsvi(gamma, stage_dependent):
     env = GridWorld(walls=(), nrows=5, ncols=5)
-    agent = RLSVIAgent(env,
-                       horizon=11,
-                       stage_dependent=stage_dependent,
-                       gamma=gamma)
+    agent = RLSVIAgent(env, horizon=11, stage_dependent=stage_dependent, gamma=gamma)
     agent.fit(budget=50)
     agent.policy(env.observation_space.sample())


### PR DESCRIPTION
Add the RLSVI algorithm (tabular).

Add the option to use Bernouillized rewards or not in the PSLR algorithm.

The shape of the std is scale/sqrt(n)+V_max/n to ease the comparison with UCBVI and simplified 
Bernstein bonuses.