### PR TITLE
feat (tests) add test of compatibility for agents and environments.

### DIFF
--- a/rlberry/tests_compatible/tests_agent.py
+++ b/rlberry/tests_compatible/tests_agent.py
@@ -1,0 +1,34 @@
+import pytest
+from rlberry.agents import *
+from rlberry.agents.torch import *
+from rlberry.envs.finite import Chain
+from rlberry.utils.check_discrete_action_agent import (
+    check_finiteMDP_agent,
+    check_continuous_state_agent,
+)
+
+FINITE_MDP_AGENTS = [
+    ValueIterationAgent,
+    MBQVIAgent,
+    UCBVIAgent,
+]
+
+
+CONTINUOUS_STATE_AGENTS = [
+    RSUCBVIAgent,
+    RSKernelUCBVIAgent,
+    OptQLAgent,
+    LSVIUCBAgent,
+    DQNAgent,
+    REINFORCEAgent,
+]
+
+
+@pytest.mark.parametrize("Agent", FINITE_MDP_AGENTS)
+def test_finite_state_agent(Agent):
+    assert check_finiteMDP_agent(Agent)
+
+
+# @pytest.mark.parametrize("Agent", CONTINUOUS_STATE_AGENTS)
+# def test_continuous_state_agent(Agent):
+#     assert check_continuous_state_agent(Agent)

--- a/rlberry/tests_compatible/tests_envs.py
+++ b/rlberry/tests_compatible/tests_envs.py
@@ -1,0 +1,25 @@
+from rlberry.utils.check_env import check_env
+from rlberry.envs import Acrobot
+from rlberry.envs.benchmarks.ball_exploration import PBall2D
+from rlberry.envs.benchmarks.generalization.twinrooms import TwinRooms
+from rlberry.envs.benchmarks.grid_exploration.apple_gold import AppleGold
+from rlberry.envs.benchmarks.grid_exploration.nroom import NRoom
+from rlberry.envs.classic_control import MountainCar
+from rlberry.envs.finite import Chain, GridWorld
+import pytest
+
+ALL_ENVS = [
+    Acrobot,
+    PBall2D,
+    TwinRooms,
+    AppleGold,
+    NRoom,
+    MountainCar,
+    Chain,
+    GridWorld,
+]
+
+
+@pytest.mark.parametrize("Env", ALL_ENVS)
+def test_env(Env):
+    check_env(Env())

--- a/rlberry/utils/__init__.py
+++ b/rlberry/utils/__init__.py
@@ -1,0 +1,1 @@
+from .check_discrete_action_agent import check_finiteMDP_agent

--- a/rlberry/utils/check_discrete_action_agent.py
+++ b/rlberry/utils/check_discrete_action_agent.py
@@ -1,0 +1,58 @@
+from rlberry.envs import Chain
+from rlberry.envs.benchmarks.ball_exploration import PBall2D
+from rlberry.agents import ValueIterationAgent
+from rlberry.manager import AgentManager, evaluate_agents
+import numpy as np
+
+
+def check_finiteMDP_agent(Agent):
+    env_ctor = Chain
+    env_kwargs = {}
+
+    agent1 = AgentManager(
+        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+    )
+    agent2 = AgentManager(
+        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+    )
+
+    agent1.fit()
+    agent2.fit()
+    env = env_ctor(**env_kwargs)
+    state = env.reset()
+    action1 = agent1.agent_handlers[0].policy(state)
+    action2 = agent2.agent_handlers[0].policy(state)
+
+    return action1 == action2
+
+
+def check_continuous_state_agent(Agent):
+    env_ctor = PBall2D
+    env_kwargs = {}
+
+    agent1 = AgentManager(
+        Agent,
+        (env_ctor, env_kwargs),
+        fit_budget=2,
+        n_fit=1,
+        init_kwargs={"horizon": 3},
+        seed=42,
+    )
+    agent2 = AgentManager(
+        Agent,
+        (env_ctor, env_kwargs),
+        fit_budget=2,
+        n_fit=1,
+        init_kwargs={"horizon": 3},
+        seed=42,
+    )
+
+    agent1.fit()
+    agent2.fit()
+    env = env_ctor(**env_kwargs)
+    state = env.reset()
+
+    action1 = agent1.agent_handlers[0].policy(state)
+    action2 = agent2.agent_handlers[0].policy(state)
+
+    return np.mean(action1 == action2) == 1

--- a/rlberry/utils/check_env.py
+++ b/rlberry/utils/check_env.py
@@ -1,0 +1,23 @@
+from rlberry.seeding import safe_reseed
+from rlberry.seeding import Seeder
+from copy import deepcopy
+import numpy as np
+
+seeder = Seeder(42)
+
+
+def check_env(env):
+    # Test if env adheres to Gym API
+    action = env.action_space.sample()
+    safe_reseed(env, Seeder(42))
+    env.reset()
+    a = env.step(action)[0]
+
+    safe_reseed(env, Seeder(42))
+    env.reset()
+    b = env.step(action)[0]
+    if hasattr(a, "__len__"):
+        print(a, b)
+        assert np.mean(np.array(a) == np.array(b)) == 1
+    else:
+        assert a == b


### PR DESCRIPTION
The goal is to add check functions and tests to assess compatibility of agents and envs in rlberry.

- [ ] test seeding in discrete state agents
- [ ] test seeding in continuous state agents
- [ ] test seeding in environments
- [ ] test compatibility with agent manager
- [ ] test compatibility with hyperparameter optimization
- [ ] test compatibility with save and load functions (in particular, must have _writer for plots)