### PR TITLE
[MRG] feat (check) add explanation about spawn error

### DIFF
--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -552,9 +552,9 @@ class AgentManager:
                 _check_not_importing_main()
             except RuntimeError as exc:
                 raise RuntimeError(
-                    """Warning: in AgentManager, if mp_context='spawn'
-                                   then the script must be run outside a notebook
-                                   and protected by a  if __name__ == '__main__':
+                    """Warning: in AgentManager, if mp_context='spawn' and
+                        parallelization="process" then the script must be run *
+                        outside a notebook and protected by a  if __name__ == '__main__':
                                    For instance :
 
                                        agent = AgentManager(UCBVIAgent,(Chain, {}),

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -257,23 +257,6 @@ class AgentManager:
 
         self.seeder = Seeder(seed)
         self.eval_seeder = self.seeder.spawn(1)
-        if mp_context == "spawn":
-            try:
-                _check_not_importing_main()
-            except RuntimeError as exc:
-                raise RuntimeError(
-                    """Warning: in AgentManager, if mp_context='spawn'
-                                   then the script must be run outside a notebook
-                                   and protected by a  if __name__ == '__main__':
-                                   For instance :
-
-                                       agent = AgentManager(UCBVIAgent,(Chain, {}),
-                                                            mp_context="spawn",
-                                                            parallelization="process")
-                                       if __name__ == '__main__':
-                                           agent.fit(10)
-                                   """
-                ) from exc
 
         self.agent_name = agent_name
         if agent_name is None:
@@ -562,6 +545,25 @@ class AgentManager:
         """
         del kwargs
         budget = budget or self.fit_budget
+
+        # If spawn, test that protected by if __name__ == "__main__"
+        if self.mp_context == "spawn":
+            try:
+                _check_not_importing_main()
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    """Warning: in AgentManager, if mp_context='spawn'
+                                   then the script must be run outside a notebook
+                                   and protected by a  if __name__ == '__main__':
+                                   For instance :
+
+                                       agent = AgentManager(UCBVIAgent,(Chain, {}),
+                                                            mp_context="spawn",
+                                                            parallelization="process")
+                                       if __name__ == '__main__':
+                                           agent.fit(10)
+                                   """
+                ) from exc
 
         logger.info(
             f"Running AgentManager fit() for {self.agent_name}"

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -16,6 +16,7 @@ import pandas as pd
 import shutil
 import threading
 import multiprocessing
+from multiprocessing.spawn import _check_not_importing_main
 import numpy as np
 from rlberry.envs.utils import process_env
 from rlberry.utils.logging import configure_logging
@@ -256,6 +257,23 @@ class AgentManager:
 
         self.seeder = Seeder(seed)
         self.eval_seeder = self.seeder.spawn(1)
+        if mp_context == "spawn":
+            try:
+                _check_not_importing_main()
+            except RuntimeError as exc:
+                raise RuntimeError(
+                    """Warning: in AgentManager, if mp_context='spawn'
+                                   then the script must be run outside a notebook
+                                   and protected by a  if __name__ == '__main__':
+                                   For instance :
+
+                                       agent = AgentManager(UCBVIAgent,(Chain, {}),
+                                                            mp_context="spawn",
+                                                            parallelization="process")
+                                       if __name__ == '__main__':
+                                           agent.fit(10)
+                                   """
+                ) from exc
 
         self.agent_name = agent_name
         if agent_name is None:

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -553,15 +553,15 @@ class AgentManager:
             except RuntimeError as exc:
                 raise RuntimeError(
                     """Warning: in AgentManager, if mp_context='spawn' and
-                        parallelization="process" then the script must be run *
+                        parallelization="process" then the script must be run
                         outside a notebook and protected by a  if __name__ == '__main__':
-                                   For instance :
+                        For example:
+                            if __name__ == '__main__':
+                                agent = AgentManager(UCBVIAgent,(Chain, {}),
+                                                mp_context="spawn",
+                                                parallelization="process")
 
-                                       agent = AgentManager(UCBVIAgent,(Chain, {}),
-                                                            mp_context="spawn",
-                                                            parallelization="process")
-                                       if __name__ == '__main__':
-                                           agent.fit(10)
+                                agent.fit(10)
                                    """
                 ) from exc
 


### PR DESCRIPTION
Should solve Issue #116

When fitting an agent manager, if the code is not behind ` if __name__ == '__main__':`, throw the following error.

```
Warning: in AgentManager, if mp_context='spawn' and
                        parallelization="process" then the script must be run *
                        outside a notebook and protected by a  if __name__ == '__main__':
                                   For instance :

                                       agent = AgentManager(UCBVIAgent,(Chain, {}),
                                                            mp_context="spawn",
                                                            parallelization="process")
                                       if __name__ == '__main__':
                                           agent.fit(10)
```