### PR TITLE
[MRG] feat (bandits) Randomized agents

### DIFF
--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -16,12 +16,12 @@ from rlberry.wrappers import WriterWrapper
 # Agents definition
 
 
-class Thompson_samplingAgent(TSAgent):
-    """Thompson_ sampling for bernoulli rvs"""
+class BernoulliTSAgent(TSAgent):
+    """Thompson sampling for bernoulli rvs"""
 
     name = "Thompson sampling"
 
-    def __init__(self, env, B=1, **kwargs):
+    def __init__(self, env, **kwargs):
         TSAgent.__init__(self, env, "beta", **kwargs)
         self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
@@ -54,7 +54,7 @@ agents = [
         fit_budget=T,
         n_fit=M,
     )
-    for Agent in [UCBAgent, Thompson_samplingAgent]
+    for Agent in [UCBAgent, BernoulliTSAgent]
 ]
 
 # Agent training

--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -64,8 +64,8 @@ for agent in agents:
 
 
 # Compute and plot (pseudo-)regret
-def compute_pseudo_regret(action):
-    return np.cumsum(np.max(means) - means[action.astype(int)])
+def compute_pseudo_regret(actions):
+    return np.cumsum(np.max(means) - means[actions.astype(int)])
 
 
 output = plot_writer_data(

--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -23,7 +23,7 @@ class Thompson_samplingAgent(TSAgent):
 
     def __init__(self, env, B=1, **kwargs):
         TSAgent.__init__(self, env, "beta", **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
 class UCBAgent(RecursiveIndexAgent):
@@ -33,11 +33,11 @@ class UCBAgent(RecursiveIndexAgent):
         RecursiveIndexAgent.__init__(
             self, env, **kwargs
         )  # default is UCB for Bernoulli.
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
 # Parameters of the problem
-means = [0.8, 0.8, 0.9, 1]  # means of the arms
+means = np.array([0.8, 0.8, 0.9, 1])  # means of the arms
 A = len(means)
 T = 2000  # Horizon
 M = 10  # number of MC simu
@@ -63,14 +63,14 @@ for agent in agents:
     agent.fit()
 
 
-# Compute and plot regret
-def compute_regret(regret):
-    return np.cumsum(np.max(means) - regret)
+# Compute and plot (pseudo-)regret
+def compute_pseudo_regret(action):
+    return np.cumsum(np.max(means) - means[action.astype(int)])
 
 
 output = plot_writer_data(
     agents,
-    tag="reward",
-    preprocess_func=compute_regret,
-    title="Cumulative Regret",
+    tag="action",
+    preprocess_func=compute_pseudo_regret,
+    title="Cumulative Pseudo-Regret",
 )

--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -17,7 +17,7 @@ from rlberry.wrappers import WriterWrapper
 
 
 class BernoulliTSAgent(TSAgent):
-    """Thompson sampling for bernoulli rvs"""
+    """Thompson sampling for Bernoulli rvs"""
 
     name = "Thompson sampling"
 

--- a/examples/demo_bandits/plot_compare_index_bandits.py
+++ b/examples/demo_bandits/plot_compare_index_bandits.py
@@ -120,8 +120,8 @@ def compute_regret(rewards):
 
 
 # Compute and plot (pseudo-)regret
-def compute_pseudo_regret(action):
-    return np.cumsum(np.max(means) - means[action.astype(int)])
+def compute_pseudo_regret(actions):
+    return np.cumsum(np.max(means) - means[actions.astype(int)])
 
 
 output = plot_writer_data(

--- a/examples/demo_bandits/plot_compare_index_bandits.py
+++ b/examples/demo_bandits/plot_compare_index_bandits.py
@@ -8,7 +8,7 @@ how to use subplots in with `plot_writer_data`
 """
 import numpy as np
 from rlberry.envs.bandits import BernoulliBandit
-from rlberry.agents.bandits import IndexAgent
+from rlberry.agents.bandits import IndexAgent, RandomizedAgent
 from rlberry.manager import AgentManager, plot_writer_data
 import matplotlib.pyplot as plt
 from rlberry.wrappers import WriterWrapper
@@ -18,7 +18,7 @@ from rlberry.wrappers import WriterWrapper
 
 
 # Parameters of the problem
-means = [0.8, 0.8, 0.9, 1]  # means of the arms
+means = np.array([0.6, 0.6, 0.6, 0.9])  # means of the arms
 A = len(means)
 T = 2000  # Horizon
 M = 10  # number of MC simu
@@ -73,7 +73,29 @@ class MOSSAgent(IndexAgent):
         )
 
 
-Agents_class = [UCBAgent, ETCAgent, MOSSAgent]
+class EXP3Agent(RandomizedAgent):
+    name = "EXP3"
+
+    def __init__(self, env, **kwargs):
+        def index(r, p, t):
+            return np.sum(1 - (1 - r) / p)
+
+        def prob(indices, t):
+            eta = np.minimum(
+                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
+                1.
+            )
+            w = np.exp(eta * indices)
+            w /= w.sum()
+            return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+
+        RandomizedAgent.__init__(self, env, index, prob, **kwargs)
+        self.env = WriterWrapper(
+            self.env, self.writer, write_scalar="action_and_reward"
+        )
+
+
+Agents_class = [UCBAgent, ETCAgent, MOSSAgent, EXP3Agent]
 
 agents = [
     AgentManager(
@@ -96,9 +118,20 @@ for agent in agents:
 
 
 # Compute and plot regret
-def compute_regret(regret):
-    return np.cumsum(np.max(means) - regret)
+def compute_regret(rewards):
+    return np.cumsum(np.max(means) - rewards)
 
+# Compute and plot (pseudo-)regret
+def compute_pseudo_regret(action):
+    return np.cumsum(np.max(means) - means[action.astype(int)])
+
+
+output = plot_writer_data(
+    agents,
+    tag="action",
+    preprocess_func=compute_pseudo_regret,
+    title="Cumulative Pseudo-Regret",
+)
 
 output = plot_writer_data(
     agents,
@@ -107,6 +140,7 @@ output = plot_writer_data(
     title="Cumulative Regret",
 )
 
+
 # Compute and plot number of times each arm was selected
 def compute_na(actions, a):
     return np.cumsum(actions == a)
@@ -114,7 +148,7 @@ def compute_na(actions, a):
 
 fig, axes = plt.subplots(2, 2, sharey=True, figsize=(6, 6))
 axes = axes.ravel()
-for arm in range(4):
+for arm in range(A):
     output = plot_writer_data(
         agents,
         tag="action",

--- a/examples/demo_bandits/plot_compare_index_bandits.py
+++ b/examples/demo_bandits/plot_compare_index_bandits.py
@@ -81,10 +81,7 @@ class EXP3Agent(RandomizedAgent):
             return np.sum(1 - (1 - r) / p)
 
         def prob(indices, t):
-            eta = np.minimum(
-                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
-                1.
-            )
+            eta = np.minimum(np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0)
             w = np.exp(eta * indices)
             w /= w.sum()
             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
@@ -120,6 +117,7 @@ for agent in agents:
 # Compute and plot regret
 def compute_regret(rewards):
     return np.cumsum(np.max(means) - rewards)
+
 
 # Compute and plot (pseudo-)regret
 def compute_pseudo_regret(action):

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -8,10 +8,9 @@ randomized algorithm.
 """
 
 import numpy as np
-from rlberry.envs.bandits import BernoulliBandit
-from rlberry.agents.bandits import RandomizedAgent
+from rlberry.envs.bandits import AdversarialBandit
+from rlberry.agents.bandits import RandomizedAgent, TSAgent
 from rlberry.manager import AgentManager, plot_writer_data
-import matplotlib.pyplot as plt
 from rlberry.wrappers import WriterWrapper
 
 
@@ -26,53 +25,96 @@ class EXP3Agent(RandomizedAgent):
             return np.sum(1 - (1 - r) / p)
 
         def prob(indices, t):
-            eta = np.minimum(np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0)
+            eta = np.minimum(
+                np.sqrt(np.log(self.n_arms) / (self.n_arms * (t + 1))),
+                1 / self.n_arms,
+            )
             w = np.exp(eta * indices)
             w /= w.sum()
-            return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+            return (1 - self.n_arms * eta) * w + eta * np.ones(self.n_arms)
 
         RandomizedAgent.__init__(self, env, index, prob, **kwargs)
         self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
+class BernoulliTSAgent(TSAgent):
+    """Thompson sampling for Bernoulli rvs"""
+
+    name = "Thompson sampling"
+
+    def __init__(self, env, **kwargs):
+        TSAgent.__init__(self, env, "beta", **kwargs)
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+
+
 # Parameters of the problem
-means = np.array([0.4, 0.5, 0.6])  # means of the arms
 T = 3000  # Horizon
 M = 20  # number of MC simu
 
+
+def switching_rewards(T, gap=0.1, rate=1.6):
+    """Adversarially switching rewards over exponentially long phases.
+    Inspired by Zimmert, Julian, and Yevgeny Seldin.
+    "Tsallis-INF: An Optimal Algorithm for Stochastic and Adversarial Bandits."
+    J. Mach. Learn. Res. 22 (2021): 28-1.
+    """
+    rewards = np.zeros((T, 2))
+    t = 0
+    exp = 1
+    high_rewards = True
+    for t in range(T):
+        if t > np.floor(rate**exp):
+            high_rewards = not high_rewards
+            exp += 1
+        if high_rewards:
+            rewards[t] = [1.0 - gap, 1.0]
+        else:
+            rewards[t] = [0.0, gap]
+    return rewards
+
+
+rewards = switching_rewards(T, rate=5.0)
+
+
 # Construction of the experiment
 
-env_ctor = BernoulliBandit
-env_kwargs = {"p": means}
+env_ctor = AdversarialBandit
+env_kwargs = {"rewards": rewards}
 
-agent = AgentManager(
-    EXP3Agent,
-    (env_ctor, env_kwargs),
-    fit_budget=T,
-    init_kwargs={},
-    n_fit=M,
-    parallelization="process",
-    mp_context="fork",
-)
+Agents_class = [EXP3Agent, BernoulliTSAgent]
+
+agents = [
+    AgentManager(
+        Agent,
+        (env_ctor, env_kwargs),
+        init_kwargs={},
+        fit_budget=T,
+        n_fit=M,
+        parallelization="process",
+        mp_context="fork",
+    )
+    for Agent in Agents_class
+]
+
 # these parameters should give parallel computing even in notebooks
 
 
 # Agent training
-
-agent.fit()
+for agent in agents:
+    agent.fit()
 
 
 # Compute and plot (pseudo-)regret
-def compute_pseudo_regret(action):
-    return np.cumsum(np.max(means) - means[action.astype(int)])
+def compute_pseudo_regret(actions):
+    selected_rewards = np.array(
+        [rewards[t, int(action)] for t, action in enumerate(actions)]
+    )
+    return np.cumsum(np.max(rewards, axis=1) - selected_rewards)
 
 
-fig = plt.figure(1, figsize=(5, 3))
-ax = plt.gca()
 output = plot_writer_data(
-    [agent],
+    agents,
     tag="action",
     preprocess_func=compute_pseudo_regret,
     title="Cumulative Pseudo-Regret",
-    ax=ax,
 )

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -32,18 +32,18 @@ class EXP3Agent(RandomizedAgent):
             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
 
         RandomizedAgent.__init__(self, env, index, prob, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
 # Parameters of the problem
-p = [0.4, 0.5, 0.6]  # means of the arms
+means = np.array([0.4, 0.5, 0.6])  # means of the arms
 T = 3000  # Horizon
 M = 20  # number of MC simu
 
 # Construction of the experiment
 
 env_ctor = BernoulliBandit
-env_kwargs = {"p": p}
+env_kwargs = {"p": means}
 
 agent = AgentManager(
     EXP3Agent,
@@ -62,17 +62,17 @@ agent = AgentManager(
 agent.fit()
 
 
-# Compute and plot regret
-def compute_regret(regret):
-    return np.cumsum(np.max(p) - regret)
+# Compute and plot (pseudo-)regret
+def compute_pseudo_regret(action):
+    return np.cumsum(np.max(means) - means[action.astype(int)])
 
 
 fig = plt.figure(1, figsize=(5, 3))
 ax = plt.gca()
 output = plot_writer_data(
     [agent],
-    tag="reward",
-    preprocess_func=compute_regret,
-    title="Cumulative Regret",
+    tag="action",
+    preprocess_func=compute_pseudo_regret,
+    title="Cumulative Pseudo-Regret",
     ax=ax,
 )

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -1,0 +1,83 @@
+"""
+=============================
+EXP3 Bandit cumulative regret
+=============================
+
+This script shows how to define a bandit environment and an EXP3
+randomized algorithm.
+"""
+
+import numpy as np
+from rlberry.envs.bandits import BernoulliBandit
+from rlberry.agents.bandits import RandomizedAgent
+from rlberry.manager import AgentManager, plot_writer_data
+import matplotlib.pyplot as plt
+from rlberry.wrappers import WriterWrapper
+
+
+# Agents definition
+
+
+class EXP3Agent(RandomizedAgent):
+    name = "EXP3"
+
+    def __init__(self, env, **kwargs):
+        def index(r, p, t):
+            return np.sum(1 - (1 - r) / p)
+
+        def prob(indices, t):
+            eta = np.minimum(
+                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
+                1.
+            )
+            w = np.exp(eta * indices)
+            w /= w.sum()
+            return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+
+        RandomizedAgent.__init__(self, env, index, prob, **kwargs)
+        self.env = WriterWrapper(
+            self.env, self.writer, write_scalar="reward"
+        )
+
+
+# Parameters of the problem
+p = [0.4, 0.5, 0.6]  # means of the arms
+T = 3000  # Horizon
+M = 20  # number of MC simu
+
+# Construction of the experiment
+
+env_ctor = BernoulliBandit
+env_kwargs = {"p": p}
+
+agent = AgentManager(
+    EXP3Agent,
+    (env_ctor, env_kwargs),
+    fit_budget=T,
+    init_kwargs={},
+    n_fit=M,
+    parallelization="process",
+    mp_context="fork",
+)
+# these parameters should give parallel computing even in notebooks
+
+
+# Agent training
+
+agent.fit()
+
+
+# Compute and plot regret
+def compute_regret(regret):
+    return np.cumsum(np.max(p) - regret)
+
+
+fig = plt.figure(1, figsize=(5, 3))
+ax = plt.gca()
+output = plot_writer_data(
+    [agent],
+    tag="reward",
+    preprocess_func=compute_regret,
+    title="Cumulative Regret",
+    ax=ax,
+)

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -26,18 +26,13 @@ class EXP3Agent(RandomizedAgent):
             return np.sum(1 - (1 - r) / p)
 
         def prob(indices, t):
-            eta = np.minimum(
-                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
-                1.
-            )
+            eta = np.minimum(np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0)
             w = np.exp(eta * indices)
             w /= w.sum()
             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
 
         RandomizedAgent.__init__(self, env, index, prob, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="reward"
-        )
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
 
 
 # Parameters of the problem

--- a/examples/demo_bandits/plot_ucb_bandit.py
+++ b/examples/demo_bandits/plot_ucb_bandit.py
@@ -67,8 +67,8 @@ agent.fit()
 
 
 # Compute and plot (pseudo-)regret
-def compute_pseudo_regret(action):
-    return np.cumsum(np.max(means) - means[action.astype(int)])
+def compute_pseudo_regret(actions):
+    return np.cumsum(np.max(means) - means[actions.astype(int)])
 
 
 fig = plt.figure(1, figsize=(5, 3))

--- a/examples/demo_bandits/plot_ucb_bandit.py
+++ b/examples/demo_bandits/plot_ucb_bandit.py
@@ -36,11 +36,11 @@ class UCBAgent(RecursiveIndexAgent):
             return stat + B * np.sqrt(2 * np.log(t**2) / Na)
 
         RecursiveIndexAgent.__init__(self, env, stat_function, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
 # Parameters of the problem
-means = [0, 0.9, 1]  # means of the arms
+means = np.array([0, 0.9, 1])  # means of the arms
 T = 3000  # Horizon
 M = 20  # number of MC simu
 
@@ -66,17 +66,17 @@ agent = AgentManager(
 agent.fit()
 
 
-# Compute and plot regret
-def compute_regret(regret):
-    return np.cumsum(np.max(means) - regret)
+# Compute and plot (pseudo-)regret
+def compute_pseudo_regret(action):
+    return np.cumsum(np.max(means) - means[action.astype(int)])
 
 
 fig = plt.figure(1, figsize=(5, 3))
 ax = plt.gca()
 output = plot_writer_data(
     [agent],
-    tag="reward",
-    preprocess_func=compute_regret,
-    title="Cumulative Regret",
+    tag="action",
+    preprocess_func=compute_pseudo_regret,
+    title="Cumulative Pseudo-Regret",
     ax=ax,
 )

--- a/rlberry/agents/bandits/__init__.py
+++ b/rlberry/agents/bandits/__init__.py
@@ -1,3 +1,4 @@
 from .bandit_base import BanditWithSimplePolicy
 from .index_agents import *
+from .randomized_agents import *
 from .thompson_sampling import TSAgent

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -26,7 +26,7 @@ class BanditWithSimplePolicy(AgentWithSimplePolicy):
     def __init__(self, env, **kwargs):
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
-        self.arms = self.env._actions
+        self.arms = np.arange(self.n_arms)
         self.total_time = 0
 
     def fit(self, budget=None, **kwargs):

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -26,7 +26,7 @@ class BanditWithSimplePolicy(AgentWithSimplePolicy):
     def __init__(self, env, **kwargs):
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
-        self.arms = range(self.n_arms)
+        self.arms = self.env._actions
         self.total_time = 0
 
     def fit(self, budget=None, **kwargs):

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -26,6 +26,7 @@ class BanditWithSimplePolicy(AgentWithSimplePolicy):
     def __init__(self, env, **kwargs):
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
+        self.arms = range(self.n_arms)
         self.total_time = 0
 
     def fit(self, budget=None, **kwargs):

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -26,7 +26,7 @@ class BanditWithSimplePolicy(AgentWithSimplePolicy):
     def __init__(self, env, **kwargs):
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
-        self.arms = np.arange(self.n_arms)
+        self.arms = self.env._actions
         self.total_time = 0
 
     def fit(self, budget=None, **kwargs):

--- a/rlberry/agents/bandits/index_agents.py
+++ b/rlberry/agents/bandits/index_agents.py
@@ -36,7 +36,6 @@ class IndexAgent(BanditWithSimplePolicy):
 
     def __init__(self, env, index_function=None, **kwargs):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
-        self.n_arms = self.env.action_space.n
         if index_function is None:
 
             def index(r, t):

--- a/rlberry/agents/bandits/index_agents.py
+++ b/rlberry/agents/bandits/index_agents.py
@@ -38,6 +38,7 @@ class IndexAgent(BanditWithSimplePolicy):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
         if index_function is None:
+
             def index(r, t):
                 return np.mean(r) + np.sqrt(np.log(t**2) / (2 * len(r)))
 

--- a/rlberry/agents/bandits/index_agents.py
+++ b/rlberry/agents/bandits/index_agents.py
@@ -34,11 +34,10 @@ class IndexAgent(BanditWithSimplePolicy):
 
     name = "IndexAgent"
 
-    def __init__(self, env, index_function=lambda rew, t: np.mean(rew), **kwargs):
+    def __init__(self, env, index_function=None, **kwargs):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
         if index_function is None:
-
             def index(r, t):
                 return np.mean(r) + np.sqrt(np.log(t**2) / (2 * len(r)))
 
@@ -52,25 +51,25 @@ class IndexAgent(BanditWithSimplePolicy):
         rewards = np.zeros(horizon)
         actions = np.ones(horizon) * np.nan
 
-        indexes = np.inf * np.ones(self.n_arms)
+        indices = np.inf * np.ones(self.n_arms)
         for ep in range(horizon):
             if self.total_time < self.n_arms:
                 action = self.total_time
             else:
-                indexes = self.get_indexes(rewards, actions, ep)
-                action = np.argmax(indexes)
+                indices = self.get_indices(rewards, actions, ep)
+                action = np.argmax(indices)
             self.total_time += 1
             _, reward, _, _ = self.env.step(action)
             rewards[ep] = reward
             actions[ep] = action
 
-        self.optimal_action = np.argmax(indexes)
+        self.optimal_action = np.argmax(indices)
         info = {"episode_reward": np.sum(rewards)}
         return info
 
-    def get_indexes(self, rewards, actions, ep):
+    def get_indices(self, rewards, actions, ep):
         """
-        Return the indexes of each arms.
+        Return the indices of each arm.
 
         Parameters
         ----------
@@ -85,16 +84,16 @@ class IndexAgent(BanditWithSimplePolicy):
             current iteration/epoch
 
         """
-        indexes = np.zeros(self.n_arms)
-        for a in range(self.n_arms):
-            indexes[a] = self.index_function(rewards[actions == a], ep)
-        return indexes
+        indices = np.zeros(self.n_arms)
+        for a in self.arms:
+            indices[a] = self.index_function(rewards[actions == a], ep)
+        return indices
 
 
 class RecursiveIndexAgent(BanditWithSimplePolicy):
     """
     Agent for bandit environment using Index-based policy like UCB with
-    recursive indexes.
+    recursive indices.
 
     Parameters
     -----------
@@ -162,7 +161,7 @@ class RecursiveIndexAgent(BanditWithSimplePolicy):
 
     def fit(self, budget=None, **kwargs):
         horizon = budget
-        indexes = np.inf * np.ones(self.n_arms)
+        indices = np.inf * np.ones(self.n_arms)
         stats = None
         Na = np.zeros(self.n_arms)
         total_reward = 0
@@ -170,21 +169,21 @@ class RecursiveIndexAgent(BanditWithSimplePolicy):
             if self.total_time < self.n_arms:
                 action = self.total_time
             else:
-                indexes = self.get_recursive_indexes(stats, Na, ep)
-                action = np.argmax(indexes)
+                indices = self.get_recursive_indices(stats, Na, ep)
+                action = np.argmax(indices)
             self.total_time += 1
             Na[action] += 1
             _, reward, _, _ = self.env.step(action)
             stats = self.stat_function(stats, Na, action, reward)
             total_reward += reward
 
-        self.optimal_action = np.argmax(indexes)
+        self.optimal_action = np.argmax(indices)
 
         info = {"episode_reward": total_reward}
         return info
 
-    def get_recursive_indexes(self, stats, Na, ep):
-        indexes = np.zeros(self.n_arms)
-        for a in range(self.n_arms):
-            indexes[a] = self.index_function(stats[a], Na[a], ep)
-        return indexes
+    def get_recursive_indices(self, stats, Na, ep):
+        indices = np.zeros(self.n_arms)
+        for a in self.arms:
+            indices[a] = self.index_function(stats[a], Na[a], ep)
+        return indices

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -1,0 +1,123 @@
+import numpy as np
+from rlberry.agents.bandits import BanditWithSimplePolicy
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class RandomizedAgent(BanditWithSimplePolicy):
+    """
+    Agent for bandit environment using randomized policy like EXP3.
+
+    Parameters
+    -----------
+    env : rlberry bandit environment
+        See :class:`~rlberry.envs.bandits.Bandit`.
+
+    index_function : callable or None, default = None
+        Compute the index for an arm using the past rewards and sampling
+        probability on this arm and the current time t.
+        If None, use loss-based importance weighted estimator.
+
+    prob_function : callable or None, default = None
+        Compute the sampling probability for an arm using its index.
+        If None, use exponential softmax probabilities with any learning rate.
+
+    Examples
+    --------
+    >>> from rlberry.agents.bandits import IndexAgent
+    >>> import numpy as np
+    >>> class EXP3Agent(RandomizedAgent):
+    >>>     name = "EXP3"
+    >>>     def __init__(self, env, **kwargs):
+    >>>         def index(r, p, t):
+    >>>             return np.sum(1 - (1 - r) / p)
+    >>>
+    >>>         def prob(indices, t):
+    >>>             eta = np.minimum(
+    >>>                 np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
+    >>>                 1.
+    >>>             )
+    >>>             w = np.exp(eta * indices)
+    >>>             w /= w.sum()
+    >>>             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+    >>>
+    >>>         RandomizedAgent.__init__(self, env, index, prob, **kwargs)
+
+    """
+
+    name = "RandomizedAgent"
+
+    def __init__(self, env, index_function=None, prob_function=None, **kwargs):
+        BanditWithSimplePolicy.__init__(self, env, **kwargs)
+        self.n_arms = self.env.action_space.n
+        if index_function is None:
+            def index_function(r, p, t):
+                return np.sum(1 - (1 - r) / p)
+
+            self.index_function = index_function
+        else:
+            self.index_function = index_function
+
+        if prob_function is None:
+            def prob_function(indices, t):
+                eta = np.minimum(
+                    np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
+                    1.
+                )
+                w = np.exp(eta * indices)
+                w /= w.sum()
+                print(w)
+                return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+
+            self.prob_function = prob_function
+        else:
+            self.prob_function = prob_function
+        self.total_time = 0
+
+    def fit(self, budget=None, **kwargs):
+        horizon = budget
+        rewards = np.zeros(horizon)
+        actions = np.ones(horizon) * np.nan
+        probs = np.ones((horizon, self.n_arms)) * np.nan
+
+        indices = np.zeros(self.n_arms)
+        for ep in range(horizon):
+            probs[ep] = self.prob_function(indices, ep)
+            action = np.random.choice(self.arms, p=probs[ep])
+            indices = self.get_indices(rewards, actions, probs, ep)
+            self.total_time += 1
+            _, reward, _, _ = self.env.step(action)
+            rewards[ep] = reward
+            actions[ep] = action
+
+        self.optimal_action = np.argmax(probs)
+        info = {"episode_reward": np.sum(rewards)}
+        return info
+
+    def get_indices(self, rewards, actions, probs, ep):
+        """
+        Return the indices of each arm.
+
+        Parameters
+        ----------
+
+        rewards : array, shape (n_iterations,)
+            list of rewards until now
+
+        actions : array, shape (n_iterations,)
+            list of actions until now
+
+        probs : array, shape (self.n_arms,)
+            list of sampling probabilities for each arm
+
+        ep: int
+            current iteration/epoch
+
+        """
+        indices = np.zeros(self.n_arms)
+        for a in self.arms:
+            indices[a] = self.index_function(
+                rewards[actions == a], probs[actions == a, a], ep
+                )
+        return indices

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -85,7 +85,7 @@ class RandomizedAgent(BanditWithSimplePolicy):
         indices = np.zeros(self.n_arms)
         for ep in range(horizon):
             probs[ep] = self.prob_function(indices, ep)
-            action = np.random.choice(self.arms, p=probs[ep])
+            action = self.seeder.rng.choice(self.arms, p=probs[ep])
             indices = self.get_indices(rewards, actions, probs, ep)
             self.total_time += 1
             _, reward, _, _ = self.env.step(action)

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -68,7 +68,6 @@ class RandomizedAgent(BanditWithSimplePolicy):
                 )
                 w = np.exp(eta * indices)
                 w /= w.sum()
-                print(w)
                 return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
 
             self.prob_function = prob_function

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -50,7 +50,6 @@ class RandomizedAgent(BanditWithSimplePolicy):
 
     def __init__(self, env, index_function=None, prob_function=None, **kwargs):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
-        self.n_arms = self.env.action_space.n
         if index_function is None:
 
             def index_function(r, p, t):

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -52,6 +52,7 @@ class RandomizedAgent(BanditWithSimplePolicy):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
         self.n_arms = self.env.action_space.n
         if index_function is None:
+
             def index_function(r, p, t):
                 return np.sum(1 - (1 - r) / p)
 
@@ -60,10 +61,10 @@ class RandomizedAgent(BanditWithSimplePolicy):
             self.index_function = index_function
 
         if prob_function is None:
+
             def prob_function(indices, t):
                 eta = np.minimum(
-                    np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
-                    1.
+                    np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0
                 )
                 w = np.exp(eta * indices)
                 w /= w.sum()
@@ -119,5 +120,5 @@ class RandomizedAgent(BanditWithSimplePolicy):
         for a in self.arms:
             indices[a] = self.index_function(
                 rewards[actions == a], probs[actions == a, a], ep
-                )
+            )
         return indices

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -21,7 +21,10 @@ class RandomizedAgent(BanditWithSimplePolicy):
 
     prob_function : callable or None, default = None
         Compute the sampling probability for an arm using its index.
-        If None, use exponential softmax probabilities with any learning rate.
+        If None, EXP3 softmax probabilities.
+        References: Seldin, Yevgeny, et al. "Evaluation and analysis of the
+        performance of the EXP3 algorithm in stochastic environments.".
+        European Workshop on Reinforcement Learning. PMLR, 2013.
 
     Examples
     --------
@@ -35,12 +38,11 @@ class RandomizedAgent(BanditWithSimplePolicy):
     >>>
     >>>         def prob(indices, t):
     >>>             eta = np.minimum(
-    >>>                 np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
-    >>>                 1.
+    >>>                 np.sqrt(np.log(self.n_arms) / (self.n_arms * (t + 1))), 1 / self.n_arms
     >>>             )
     >>>             w = np.exp(eta * indices)
     >>>             w /= w.sum()
-    >>>             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+    >>>             return (1 - self.n_arms * eta) * w + eta * np.ones(self.n_arms)
     >>>
     >>>         RandomizedAgent.__init__(self, env, index, prob, **kwargs)
 
@@ -63,11 +65,12 @@ class RandomizedAgent(BanditWithSimplePolicy):
 
             def prob_function(indices, t):
                 eta = np.minimum(
-                    np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0
+                    np.sqrt(np.log(self.n_arms) / (self.n_arms * (t + 1))),
+                    1 / self.n_arms,
                 )
                 w = np.exp(eta * indices)
                 w /= w.sum()
-                return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+                return (1 - self.n_arms * eta) * w + eta * np.ones(self.n_arms)
 
             self.prob_function = prob_function
         else:

--- a/rlberry/agents/bandits/thompson_sampling.py
+++ b/rlberry/agents/bandits/thompson_sampling.py
@@ -36,7 +36,6 @@ class TSAgent(BanditWithSimplePolicy):
             raise ValueError(
                 'This prior is not implemented yet. Valid prior are "gaussian" and "beta"'
             )
-        self.n_arms = len(self.env._actions)
         if self.prior == "gaussian":
             # Initialize with all means equal to 0
             if self.prior_params is None:

--- a/rlberry/agents/bandits/thompson_sampling.py
+++ b/rlberry/agents/bandits/thompson_sampling.py
@@ -36,6 +36,7 @@ class TSAgent(BanditWithSimplePolicy):
             raise ValueError(
                 'This prior is not implemented yet. Valid prior are "gaussian" and "beta"'
             )
+        self.n_arms = len(self.env._actions)
         if self.prior == "gaussian":
             # Initialize with all means equal to 0
             if self.prior_params is None:

--- a/rlberry/agents/bandits/thompson_sampling.py
+++ b/rlberry/agents/bandits/thompson_sampling.py
@@ -26,7 +26,6 @@ class TSAgent(BanditWithSimplePolicy):
 
     def __init__(self, env, prior, prior_params=None, **kwargs):
         BanditWithSimplePolicy.__init__(self, env, **kwargs)
-        self.n_arms = self.env.action_space.n
         self.prior = prior
         self.prior_params = prior_params
         self.total_time = 0

--- a/rlberry/agents/tests/test_bandits.py
+++ b/rlberry/agents/tests/test_bandits.py
@@ -2,6 +2,7 @@ import numpy as np
 from rlberry.envs.bandits import NormalBandit, BernoulliBandit
 from rlberry.agents.bandits import (
     IndexAgent,
+    RandomizedAgent,
     RecursiveIndexAgent,
     TSAgent,
     BanditWithSimplePolicy,
@@ -45,6 +46,29 @@ def test_base_bandit():
 def test_index_bandits():
     assert check_bandit_agent(UCBAgent)
     assert check_bandit_agent(RecursiveUCBAgent)
+
+
+class EXP3Agent(RandomizedAgent):
+    name = "EXP3"
+
+    def __init__(self, env, **kwargs):
+        def index(r, p, t):
+            return np.sum(1 - (1 - r) / p)
+
+        def prob(indices, t):
+            eta = np.minimum(
+                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
+                1.
+            )
+            w = np.exp(eta * indices)
+            w /= w.sum()
+            return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms
+
+        RandomizedAgent.__init__(self, env, index, prob, **kwargs)
+
+
+def test_randomized_bandits():
+    assert check_bandit_agent(EXP3Agent)
 
 
 def test_TS():

--- a/rlberry/agents/tests/test_bandits.py
+++ b/rlberry/agents/tests/test_bandits.py
@@ -56,10 +56,7 @@ class EXP3Agent(RandomizedAgent):
             return np.sum(1 - (1 - r) / p)
 
         def prob(indices, t):
-            eta = np.minimum(
-                np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)),
-                1.
-            )
+            eta = np.minimum(np.sqrt(self.n_arms * np.log(self.n_arms) / (t + 1)), 1.0)
             w = np.exp(eta * indices)
             w /= w.sum()
             return (1 - eta) * w + eta * np.ones(self.n_arms) / self.n_arms

--- a/rlberry/agents/tests/test_bandits.py
+++ b/rlberry/agents/tests/test_bandits.py
@@ -11,6 +11,9 @@ from rlberry.manager import AgentManager
 from rlberry.utils import check_bandit_agent
 
 
+TEST_SEED = 42
+
+
 class UCBAgent(IndexAgent):
     name = "UCB Agent"
 
@@ -40,12 +43,12 @@ class RecursiveUCBAgent(RecursiveIndexAgent):
 
 
 def test_base_bandit():
-    assert check_bandit_agent(BanditWithSimplePolicy)
+    assert check_bandit_agent(BanditWithSimplePolicy, NormalBandit, seed=TEST_SEED)
 
 
 def test_index_bandits():
-    assert check_bandit_agent(UCBAgent)
-    assert check_bandit_agent(RecursiveUCBAgent)
+    assert check_bandit_agent(UCBAgent, NormalBandit, seed=TEST_SEED)
+    assert check_bandit_agent(RecursiveUCBAgent, NormalBandit, seed=TEST_SEED)
 
 
 class EXP3Agent(RandomizedAgent):
@@ -65,7 +68,7 @@ class EXP3Agent(RandomizedAgent):
 
 
 def test_randomized_bandits():
-    assert check_bandit_agent(EXP3Agent)
+    assert check_bandit_agent(EXP3Agent, BernoulliBandit, seed=TEST_SEED)
 
 
 def test_TS():
@@ -75,7 +78,7 @@ def test_TS():
         def __init__(self, env, **kwargs):
             TSAgent.__init__(self, env, "gaussian", **kwargs)
 
-    assert check_bandit_agent(TSAgent_normal)
+    assert check_bandit_agent(TSAgent_normal, NormalBandit, seed=TEST_SEED)
 
     class TSAgent_beta(TSAgent):
         name = "TSAgent"
@@ -83,7 +86,7 @@ def test_TS():
         def __init__(self, env, **kwargs):
             TSAgent.__init__(self, env, "beta", **kwargs)
 
-    assert check_bandit_agent(TSAgent_beta, BernoulliBandit)
+    assert check_bandit_agent(TSAgent_beta, BernoulliBandit, TEST_SEED)
 
 
 def test_recursive_vs_not_recursive():
@@ -91,10 +94,15 @@ def test_recursive_vs_not_recursive():
     env_kwargs = {}
 
     agent1 = AgentManager(
-        UCBAgent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+        UCBAgent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=TEST_SEED
     )
+
     agent2 = AgentManager(
-        RecursiveUCBAgent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+        RecursiveUCBAgent,
+        (env_ctor, env_kwargs),
+        fit_budget=10,
+        n_fit=1,
+        seed=TEST_SEED,
     )
 
     agent1.fit()

--- a/rlberry/envs/bandits/__init__.py
+++ b/rlberry/envs/bandits/__init__.py
@@ -1,3 +1,3 @@
 from .bandit_base import AdversarialBandit, Bandit
-from .corrupted_bandits import *
-from .stochastic_bandits import *
+from .corrupted_bandits import CorruptedLaws, CorruptedNormalBandit
+from .stochastic_bandits import BernoulliBandit, NormalBandit

--- a/rlberry/envs/bandits/__init__.py
+++ b/rlberry/envs/bandits/__init__.py
@@ -1,1 +1,3 @@
-from .bandits import *
+from .bandit_base import AdversarialBandit, Bandit
+from .corrupted_bandits import *
+from .stochastic_bandits import *

--- a/rlberry/envs/bandits/bandit_base.py
+++ b/rlberry/envs/bandits/bandit_base.py
@@ -1,0 +1,95 @@
+from collections import deque
+import logging
+
+from rlberry.envs.interface import Model
+import rlberry.spaces as spaces
+
+
+logger = logging.getLogger(__name__)
+
+
+class Bandit(Model):
+    """
+    Base class for a stochastic multi-armed bandit.
+
+    Parameters
+    ----------
+
+    laws: list of laws.
+        laws of the arms. can either be a frozen scipy law or any class that
+        has a method .rvs().
+
+    **kwargs: keywords arguments
+        additional arguments sent to :class:`~rlberry.envs.interface.Model`
+
+    """
+
+    name = ""
+
+    def __init__(self, laws=[], **kwargs):
+        Model.__init__(self, **kwargs)
+        self.laws = laws
+        self.n_arms = len(self.laws)
+        self.action_space = spaces.Discrete(self.n_arms)
+
+    def step(self, action):
+        """
+        Sample the reward associated to the action.
+        """
+        # test that the action exists
+        assert action < self.n_arms
+
+        reward = self.laws[action].rvs(random_state=self.rng)
+        done = True
+
+        return 0, reward, done, {}
+
+    def reset(self):
+        """
+        Reset the environment to a default state.
+        """
+        return 0
+
+
+class AdversarialBandit(Model):
+    """
+    Base class for a adversarial multi-armed bandit with oblivious
+    opponent, i.e all rewards are fixed in advance at the start of the run.
+
+    Parameters
+    ----------
+
+    rewards: list of rewards, shape (T, A).
+        Possible rewards up to horizon T for each of the A arms.
+
+    **kwargs: keywords arguments
+        additional arguments sent to :class:`~rlberry.envs.interface.Model`
+
+    """
+
+    name = ""
+
+    def __init__(self, rewards=[], **kwargs):
+        Model.__init__(self, **kwargs)
+        self.n_arms = rewards.shape[1]
+        self.rewards = deque(rewards)
+        self.action_space = spaces.Discrete(self.n_arms)
+
+    def step(self, action):
+        """
+        Sample the reward associated to the action.
+        """
+        # test that the action exists
+        assert action < self.n_arms
+
+        rewards = self.rewards.popleft()
+        reward = rewards[action]
+        done = True
+
+        return 0, reward, done, {}
+
+    def reset(self):
+        """
+        Reset the environment to a default state.
+        """
+        return 0

--- a/rlberry/envs/bandits/bandits.py
+++ b/rlberry/envs/bandits/bandits.py
@@ -32,7 +32,6 @@ class Bandit(Model):
         self.laws = laws
         A = len(self.laws)
         self.action_space = spaces.Discrete(A)
-        self._actions = np.arange(A)
 
     def step(self, action):
         """

--- a/rlberry/envs/bandits/bandits.py
+++ b/rlberry/envs/bandits/bandits.py
@@ -32,6 +32,7 @@ class Bandit(Model):
         self.laws = laws
         A = len(self.laws)
         self.action_space = spaces.Discrete(A)
+        self._actions = np.arange(A)
 
     def step(self, action):
         """

--- a/rlberry/envs/bandits/bandits.py
+++ b/rlberry/envs/bandits/bandits.py
@@ -30,6 +30,9 @@ class Bandit(Model):
     def __init__(self, laws=[], **kwargs):
         Model.__init__(self, **kwargs)
         self.laws = laws
+        A = len(self.laws)
+        self.action_space = spaces.Discrete(A)
+        self._actions = np.arange(A)
 
     def step(self, action):
         """
@@ -162,11 +165,8 @@ class NormalBandit(Bandit):
         means=np.array([0, 1]),
         stds=None,
     ):
-        Bandit.__init__(self)
-        self.laws = self.make_laws(means, stds)
-        A = len(self.laws)
-        self.action_space = spaces.Discrete(A)
-        self._actions = np.arange(A)
+        laws = self.make_laws(means, stds)
+        Bandit.__init__(self, laws=laws)
 
     def make_laws(self, means, stds):
         if stds is None:
@@ -193,11 +193,8 @@ class BernoulliBandit(Bandit):
         self,
         p=np.array([0.1, 0.9]),
     ):
-        Bandit.__init__(self)
-        self.laws = self.make_laws(p)
-        A = len(self.laws)
-        self.action_space = spaces.Discrete(A)
-        self._actions = np.arange(A)
+        laws = self.make_laws(p)
+        Bandit.__init__(self, laws=laws)
 
     def make_laws(self, p):
         return [stats.binom(n=1, p=p[a]) for a in range(len(p))]

--- a/rlberry/envs/bandits/bandits.py
+++ b/rlberry/envs/bandits/bandits.py
@@ -118,11 +118,8 @@ class CorruptedNormalBandit(Bandit):
         cor_prop=0.05,
         cor_laws=None,
     ):
-        Bandit.__init__(self)
-        self.laws = self.make_laws(means, stds, cor_prop, cor_laws)
-        A = len(self.laws)
-        self.action_space = spaces.Discrete(A)
-        self._actions = np.arange(A)
+        laws = self.make_laws(means, stds, cor_prop, cor_laws)
+        Bandit.__init__(self, laws=laws)
 
     def make_laws(self, means, stds, cor_prop, cor_laws):
         if cor_laws is not None:

--- a/rlberry/envs/bandits/corrupted_bandits.py
+++ b/rlberry/envs/bandits/corrupted_bandits.py
@@ -1,55 +1,7 @@
 import numpy as np
 from scipy import stats
-import logging
 
-from rlberry.envs.interface import Model
-import rlberry.spaces as spaces
-
-
-logger = logging.getLogger(__name__)
-
-
-class Bandit(Model):
-    """
-    Base class for a multi-armed Bandit.
-
-    Parameters
-    ----------
-
-    laws: list of laws.
-        laws of the arms. can either be a frozen scipy law or any class that
-        has a method .rvs().
-
-    **kwargs: keywords arguments
-        additional arguments sent to :class:`~rlberry.envs.interface.Model`
-
-    """
-
-    name = ""
-
-    def __init__(self, laws=[], **kwargs):
-        Model.__init__(self, **kwargs)
-        self.laws = laws
-        A = len(self.laws)
-        self.action_space = spaces.Discrete(A)
-
-    def step(self, action):
-        """
-        Sample the reward associated to the action.
-        """
-        # test that the action exists
-        assert action < len(self.laws)
-
-        reward = self.laws[action].rvs(random_state=self.rng)
-        done = True
-
-        return 0, reward, done, {}
-
-    def reset(self):
-        """
-        Reset the environment to a default state.
-        """
-        return 0
+from rlberry.envs.bandits import Bandit
 
 
 class CorruptedLaws:
@@ -138,59 +90,3 @@ class CorruptedNormalBandit(Bandit):
             CorruptedLaws(inlier_laws[a], cor_prop, self.cor_laws[a])
             for a in range(len(means))
         ]
-
-
-class NormalBandit(Bandit):
-    """
-    Class for Normal Bandits
-
-    Parameters
-    ----------
-
-    means: array-like of size n_arms, default=array([0,1])
-        means of the law of each of the arms.
-
-    stds: array-like of size n_arms or None, default=None
-        stds of the law of each of the arms. If None, use array with
-        all ones.
-
-    """
-
-    def __init__(
-        self,
-        means=np.array([0, 1]),
-        stds=None,
-    ):
-        laws = self.make_laws(means, stds)
-        Bandit.__init__(self, laws=laws)
-
-    def make_laws(self, means, stds):
-        if stds is None:
-            self.stds = np.ones(len(means))
-        else:
-            self.stds = stds
-        assert len(means) == len(self.stds)
-        return [stats.norm(loc=means[a], scale=self.stds[a]) for a in range(len(means))]
-
-
-class BernoulliBandit(Bandit):
-    """
-    Class for Bernoulli Bandits
-
-    Parameters
-    ----------
-
-    p: array-like of size n_arms, default=array([0.1,0.9])
-        means of the law of inliers of each of the arms.
-
-    """
-
-    def __init__(
-        self,
-        p=np.array([0.1, 0.9]),
-    ):
-        laws = self.make_laws(p)
-        Bandit.__init__(self, laws=laws)
-
-    def make_laws(self, p):
-        return [stats.binom(n=1, p=p[a]) for a in range(len(p))]

--- a/rlberry/envs/bandits/stochastic_bandits.py
+++ b/rlberry/envs/bandits/stochastic_bandits.py
@@ -1,0 +1,60 @@
+import numpy as np
+from scipy import stats
+
+from rlberry.envs.bandits import Bandit
+
+
+class NormalBandit(Bandit):
+    """
+    Class for Normal Bandits
+
+    Parameters
+    ----------
+
+    means: array-like of size n_arms, default=array([0,1])
+        means of the law of each of the arms.
+
+    stds: array-like of size n_arms or None, default=None
+        stds of the law of each of the arms. If None, use array with
+        all ones.
+
+    """
+
+    def __init__(
+        self,
+        means=np.array([0, 1]),
+        stds=None,
+    ):
+        laws = self.make_laws(means, stds)
+        Bandit.__init__(self, laws=laws)
+
+    def make_laws(self, means, stds):
+        if stds is None:
+            self.stds = np.ones(len(means))
+        else:
+            self.stds = stds
+        assert len(means) == len(self.stds)
+        return [stats.norm(loc=means[a], scale=self.stds[a]) for a in range(len(means))]
+
+
+class BernoulliBandit(Bandit):
+    """
+    Class for Bernoulli Bandits
+
+    Parameters
+    ----------
+
+    p: array-like of size n_arms, default=array([0.1,0.9])
+        means of the law of inliers of each of the arms.
+
+    """
+
+    def __init__(
+        self,
+        p=np.array([0.1, 0.9]),
+    ):
+        laws = self.make_laws(p)
+        Bandit.__init__(self, laws=laws)
+
+    def make_laws(self, p):
+        return [stats.binom(n=1, p=p[a]) for a in range(len(p))]

--- a/rlberry/envs/tests/test_bandits.py
+++ b/rlberry/envs/tests/test_bandits.py
@@ -2,6 +2,7 @@ import numpy as np
 from rlberry.seeding import safe_reseed
 from rlberry.seeding import Seeder
 from rlberry.envs.bandits import (
+    AdversarialBandit,
     BernoulliBandit,
     NormalBandit,
     CorruptedNormalBandit,
@@ -33,3 +34,17 @@ def test_cor_normal():
 
     sample = [env.step(1)[1] for f in range(1000)]
     assert np.abs(np.median(sample) - 1) < 0.5
+
+
+def test_adversarial():
+    r1 = np.concatenate((2 * np.ones((500, 1)), np.ones((500, 1))), axis=1)
+
+    r2 = np.concatenate((np.ones((500, 1)), 2 * np.ones((500, 1))), axis=1)
+
+    rewards = np.concatenate((r1, r2))
+
+    env = AdversarialBandit(rewards=rewards)
+    safe_reseed(env, Seeder(TEST_SEED))
+
+    sample = [env.step(1)[1] for f in range(1000)]
+    assert np.abs(np.mean(sample) - 1.5) < 1e-10

--- a/rlberry/envs/tests/test_bandits.py
+++ b/rlberry/envs/tests/test_bandits.py
@@ -1,12 +1,27 @@
 import numpy as np
-from rlberry.envs.bandits import NormalBandit, CorruptedNormalBandit
 from rlberry.seeding import safe_reseed
 from rlberry.seeding import Seeder
+from rlberry.envs.bandits import (
+    BernoulliBandit,
+    NormalBandit,
+    CorruptedNormalBandit,
+)
+
+
+TEST_SEED = 42
+
+
+def test_bernoulli():
+    env = BernoulliBandit(p=[0.05, 0.95])
+    safe_reseed(env, Seeder(TEST_SEED))
+
+    sample = [env.step(1)[1] for f in range(1000)]
+    assert np.abs(np.mean(sample) - 0.95) < 0.1
 
 
 def test_normal():
     env = NormalBandit(means=[0, 1])
-    safe_reseed(env, Seeder(42))
+    safe_reseed(env, Seeder(TEST_SEED))
 
     sample = [env.step(1)[1] for f in range(1000)]
     assert np.abs(np.mean(sample) - 1) < 0.1
@@ -14,7 +29,7 @@ def test_normal():
 
 def test_cor_normal():
     env = CorruptedNormalBandit(means=[0, 1], cor_prop=0.1)
-    safe_reseed(env, Seeder(42))
+    safe_reseed(env, Seeder(TEST_SEED))
 
     sample = [env.step(1)[1] for f in range(1000)]
     assert np.abs(np.median(sample) - 1) < 0.5

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -304,6 +304,9 @@ def plot_writer_data(
     if ax is None:
         figure, ax = plt.subplots(1, 1)
 
+    # PS: in the next release of seaborn, ci should be deprecated and replaced
+    # with errorbar, which allows to specifies other types of confidence bars,
+    # in particular quantiles.
     lineplot_kwargs = dict(
         x=xx, y="value", hue="name", style="name", data=data, ax=ax, ci="sd"
     )

--- a/rlberry/utils/check_bandit_agent.py
+++ b/rlberry/utils/check_bandit_agent.py
@@ -2,7 +2,7 @@ from rlberry.envs.bandits import BernoulliBandit
 from rlberry.manager import AgentManager
 
 
-def check_bandit_agent(Agent, environment=BernoulliBandit):
+def check_bandit_agent(Agent, environment=BernoulliBandit, seed=None):
     """
     Function used to check a bandit agent in rlberry on a Gaussian bandit problem.
 
@@ -11,6 +11,12 @@ def check_bandit_agent(Agent, environment=BernoulliBandit):
 
     Agent: rlberry agent module
         Agent class that we want to test.
+
+    environment: rlberry env module
+        Environment (i.e bandit instance) on which to test the agent.
+
+    seed : Seed sequence from which to spawn the random number generator.
+
 
     Returns
     -------
@@ -36,10 +42,10 @@ def check_bandit_agent(Agent, environment=BernoulliBandit):
     env_kwargs = {}
 
     agent1 = AgentManager(
-        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=seed
     )
     agent2 = AgentManager(
-        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=42
+        Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=seed
     )
 
     agent1.fit()

--- a/rlberry/utils/check_bandit_agent.py
+++ b/rlberry/utils/check_bandit_agent.py
@@ -2,7 +2,7 @@ from rlberry.envs.bandits import BernoulliBandit
 from rlberry.manager import AgentManager
 
 
-def check_bandit_agent(Agent, environment=BernoulliBandit, seed=None):
+def check_bandit_agent(Agent, environment=BernoulliBandit, seed=42):
     """
     Function used to check a bandit agent in rlberry on a Gaussian bandit problem.
 

--- a/rlberry/utils/check_bandit_agent.py
+++ b/rlberry/utils/check_bandit_agent.py
@@ -1,8 +1,8 @@
-from rlberry.envs.bandits import NormalBandit
+from rlberry.envs.bandits import BernoulliBandit
 from rlberry.manager import AgentManager
 
 
-def check_bandit_agent(Agent, environment=NormalBandit):
+def check_bandit_agent(Agent, environment=BernoulliBandit):
     """
     Function used to check a bandit agent in rlberry on a Gaussian bandit problem.
 


### PR DESCRIPTION
* Add RandomizedAgent class, inspired by IndexAgent, with default policy being EXP3 with standard, anytime hyperparam,
* Add AdversarialBandit environment, where all potential rewards are fixed in advance (oblivious opponent). 
* Refactor envs/bandits/bandits.py to remove redundant syntax when instantiating a child class.
* Refactor examples/demo_bandits to display pseudo-regret (best mean - mean of chosen arm) rather than regret (best mean - reward of chosen arm).
   * Pseudo-regret is the standard measure in bandit, and it is by definition nondecreasing, whereas regret as it is now is noisy.
* Update tests
   * Change utils/check_bandit_agent to test on BernoulliBandit rather than NormalBandit. 
      * Reason is some algo (EXP3) crucially rely on bounded rewards (by default [0, 1]). I think it's safer to test by default on Bernoulli rather than Gaussian. Also I explicitly pass the env in argument in the test for readability. 
   * Add test for BernoulliBandit env. 
   * Explicitly fixes the seed (add seed argument).