### PR TITLE
Minimize star imports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,7 +57,7 @@ jobs:
     displayName: "black"
   - script: |
       # ensure there is no unused imports with
-      flake8 --select F401 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
+      flake8 --select F401,F405 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
     displayName: 'flake8'
 
 

--- a/rlberry/agents/__init__.py
+++ b/rlberry/agents/__init__.py
@@ -1,15 +1,15 @@
-# Import interfaces
+# Interfaces
 from .agent import Agent
 from .agent import AgentWithSimplePolicy
 
-# basic agents (alphabetical!)
-# basic = does not require torch, jax etc
-from .adaptiveql import *
-from .dynprog import *
-from .kernel_based import *
-from .mbqvi import *
-from .optql import *
-from .ucbvi import *
-from .linear import *
+# Basic agents (in alphabetical order)
+# basic = does not require torch, jax, etc...
+from .adaptiveql import AdaptiveQLAgent
+from .dynprog import ValueIterationAgent
+from .kernel_based import RSUCBVIAgent, RSKernelUCBVIAgent
+from .linear import LSVIUCBAgent
+from .mbqvi import MBQVIAgent
+from .optql import OptQLAgent
 from .psrl import PSRLAgent
 from .rlsvi import RLSVIAgent
+from .ucbvi import UCBVIAgent

--- a/rlberry/agents/bandits/__init__.py
+++ b/rlberry/agents/bandits/__init__.py
@@ -1,3 +1,3 @@
 from .bandit_base import BanditWithSimplePolicy
-from .index_agents import *
+from .index_agents import IndexAgent, RecursiveIndexAgent
 from .thompson_sampling import TSAgent

--- a/rlberry/agents/torch/__init__.py
+++ b/rlberry/agents/torch/__init__.py
@@ -1,9 +1,7 @@
-# agents (alphabetical!)
-from .a2c import *
-from .avec import *
-from .dqn import *
-from .ppo import *
-from .sac import *
-from .reinforce import *
-
-# hello!
+# Torch agents (in alphabetical order)
+from .a2c import A2CAgent
+from .avec import AVECPPOAgent
+from .dqn import DQNAgent
+from .ppo import PPOAgent
+from .reinforce import REINFORCEAgent
+from .sac import SACAgent

--- a/rlberry/envs/__init__.py
+++ b/rlberry/envs/__init__.py
@@ -1,5 +1,5 @@
-from .gym_make import gym_make
+from .gym_make import gym_make, atari_make
 from .basewrapper import Wrapper
-from .classic_control import *
-from .finite import *
-from .interface import *
+from .classic_control import Acrobot, MountainCar, Pendulum
+from .finite import Chain, FiniteMDP, GridWorld
+from .interface import Model

--- a/rlberry/tests/test_agent.py
+++ b/rlberry/tests/test_agent.py
@@ -1,6 +1,6 @@
 import pytest
-from rlberry.agents import *
-from rlberry.agents.torch import *
+import rlberry.agents as agents
+import rlberry.agents.torch as torch_agents
 from rlberry.utils.check_agent import (
     check_rl_agent,
     check_save_load,
@@ -22,34 +22,34 @@ class OneHotFeatureMap(FeatureMap):
 
 
 # LSVIUCBAgent needs a feature map function to work.
-class OneHotLSVI(LSVIUCBAgent):
+class OneHotLSVI(agents.LSVIUCBAgent):
     def __init__(self, env, **kwargs):
         def feature_map_fn(_env):
             return OneHotFeatureMap(5, 2)  # values for Chain
 
-        LSVIUCBAgent.__init__(
+        agents.LSVIUCBAgent.__init__(
             self, env, feature_map_fn=feature_map_fn, horizon=10, **kwargs
         )
 
 
 FINITE_MDP_AGENTS = [
-    ValueIterationAgent,
-    MBQVIAgent,
-    UCBVIAgent,
-    OptQLAgent,
+    agents.ValueIterationAgent,
+    agents.MBQVIAgent,
+    agents.UCBVIAgent,
+    agents.OptQLAgent,
+    agents.PSRLAgent,
+    agents.RLSVIAgent,
     OneHotLSVI,
-    PSRLAgent,
-    RLSVIAgent,
 ]
 
 
 CONTINUOUS_STATE_AGENTS = [
-    RSUCBVIAgent,
-    RSKernelUCBVIAgent,
-    # DQNAgent,  # For now, DQN does not work with the generic check.
-    PPOAgent,
-    AVECPPOAgent,
-    REINFORCEAgent,
+    agents.RSUCBVIAgent,
+    agents.RSKernelUCBVIAgent,
+    # torch_agents.DQNAgent,  # For now, DQN does not work with the generic check.
+    torch_agents.PPOAgent,
+    torch_agents.AVECPPOAgent,
+    torch_agents.REINFORCEAgent,
 ]
 
 
@@ -64,4 +64,4 @@ def test_continuous_state_agent(Agent):
 
 
 def test_dqn():
-    check_save_load(DQNAgent, env="continuous_state")
+    check_save_load(torch_agents.DQNAgent, env="continuous_state")


### PR DESCRIPTION
A quick fix to #121.

I left the star imports on `rlberry/envs/bandits/__init__.py` and `rlberry/tests/test_agent.py` because they are importing multiple things while also being quite clear. Let me know what you think.

@TimotheeMathieu do you know how to set up the checks in flake8?