### PR TITLE
[MRG] Support `init_kwargs` in agent checks

### DIFF
--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -49,8 +49,9 @@ def _fit_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
     train_env = _make_env(env)
     try:
-        agent = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED,
-            init_kwargs=init_kwargs)
+        agent = AgentManager(
+            agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
+        )
         agent.fit()
     except Exception as exc:
         raise RuntimeError("Agent not compatible with Agent Manager") from exc
@@ -141,13 +142,15 @@ def check_fit_additive(agent, env="continuous_state", init_kwargs=None):
         init_kwargs = {}
     train_env = _make_env(env)
 
-    agent1 = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED,
-        init_kwargs=init_kwargs)
+    agent1 = AgentManager(
+        agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
+    )
     agent1.fit(3)
     agent1.fit(3)
 
-    agent2 = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED,
-        init_kwargs=init_kwargs)
+    agent2 = AgentManager(
+        agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
+    )
     agent2.fit(6)
 
     result = check_agents_almost_equal(
@@ -198,8 +201,7 @@ def check_save_load(agent, env="continuous_state", init_kwargs=None):
             raise RuntimeError("Failed to load the agent file.")
 
 
-def check_seeding_agent(agent, env=None, continuous_state=False,
-    init_kwargs=None):
+def check_seeding_agent(agent, env=None, continuous_state=False, init_kwargs=None):
     """
     Check that the agent is reproducible.
 
@@ -244,7 +246,9 @@ def check_rl_agent(agent, env="continuous_state", init_kwargs=None):
     >>> from rlberry.utils import check_rl_agent
     >>> check_rl_agent(UCBVIAgent) # which does not return an error.
     """
-    check_agent_manager(agent, env, init_kwargs=init_kwargs)  # check manager compatible.
+    check_agent_manager(
+        agent, env, init_kwargs=init_kwargs
+    )  # check manager compatible.
     check_seeding_agent(agent, env, init_kwargs=init_kwargs)  # check reproducibility
     check_fit_additive(agent, env, init_kwargs=init_kwargs)
     check_save_load(agent, env, init_kwargs=init_kwargs)

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -30,7 +30,7 @@ def _make_env(env):
     return env_ctor, env_kwargs
 
 
-def _fit_agent_manager(Agent, env="continuous_state"):
+def _fit_agent_manager(agent, env="continuous_state"):
     """
     Check that the agent is compatible with :class:`~rlberry.manager.AgentManager`.
 
@@ -46,7 +46,7 @@ def _fit_agent_manager(Agent, env="continuous_state"):
     """
     train_env = _make_env(env)
     try:
-        agent = AgentManager(Agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
+        agent = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
         agent.fit()
     except Exception as exc:
         raise RuntimeError("Agent not compatible with Agent Manager") from exc
@@ -54,7 +54,7 @@ def _fit_agent_manager(Agent, env="continuous_state"):
     return agent
 
 
-def check_agent_manager(Agent, env="continuous_state"):
+def check_agent_manager(agent, env="continuous_state"):
     """
     Check that the agent is compatible with :class:`~rlberry.manager.AgentManager`.
 
@@ -68,7 +68,7 @@ def check_agent_manager(Agent, env="continuous_state"):
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
     """
-    _ = _fit_agent_manager(Agent, env)
+    _ = _fit_agent_manager(agent, env)
 
 
 def check_agents_almost_equal(agent1, agent2, compare_using="policy", n_checks=5):
@@ -119,7 +119,7 @@ def check_agents_almost_equal(agent1, agent2, compare_using="policy", n_checks=5
     return result
 
 
-def check_fit_additive(Agent, env="continuous_state"):
+def check_fit_additive(agent, env="continuous_state"):
     """
     Check that fitting two times with 10 fit budget is the same as fitting
     one time with 20 fit budget.
@@ -135,11 +135,11 @@ def check_fit_additive(Agent, env="continuous_state"):
         if str in ["continuous_state", "discrete_state"], we use a default Benchmark environment.
     """
     train_env = _make_env(env)
-    agent1 = AgentManager(Agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
+    agent1 = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
     agent1.fit(3)
     agent1.fit(3)
 
-    agent2 = AgentManager(Agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
+    agent2 = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
     agent2.fit(6)
 
     result = check_agents_almost_equal(
@@ -151,7 +151,7 @@ def check_fit_additive(Agent, env="continuous_state"):
     ), "Error: fitting the agent two times for 10 steps is not equivalent to fitting it one time for 20 steps."
 
 
-def check_save_load(Agent, env="continuous_state"):
+def check_save_load(agent, env="continuous_state"):
     """
     Check that the agent save a non-empty file and can load.
 
@@ -170,7 +170,7 @@ def check_save_load(Agent, env="continuous_state"):
     env = train_env[0](**train_env[1])
     with tempfile.TemporaryDirectory() as tmpdirname:
         agent = AgentManager(
-            Agent,
+            agent,
             train_env,
             fit_budget=5,
             n_fit=1,
@@ -187,7 +187,7 @@ def check_save_load(Agent, env="continuous_state"):
             raise RuntimeError("Failed to load the agent file.")
 
 
-def check_seeding_agent(Agent, env=None, continuous_state=False):
+def check_seeding_agent(agent, env=None, continuous_state=False):
     """
     Check that the agent is reproducible.
 
@@ -201,8 +201,8 @@ def check_seeding_agent(Agent, env=None, continuous_state=False):
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
     """
-    agent1 = _fit_agent_manager(Agent, env)
-    agent2 = _fit_agent_manager(Agent, env)
+    agent1 = _fit_agent_manager(agent, env)
+    agent2 = _fit_agent_manager(agent, env)
 
     result = check_agents_almost_equal(
         agent1.agent_handlers[0], agent2.agent_handlers[0]
@@ -211,7 +211,7 @@ def check_seeding_agent(Agent, env=None, continuous_state=False):
     assert result, "Agent not reproducible (same seed give different results)"
 
 
-def check_rl_agent(Agent, env="continuous_state"):
+def check_rl_agent(agent, env="continuous_state"):
     """
     Check agent manager compatibility  and check reproducibility/seeding.
     Raises an exception if a check fails.
@@ -232,7 +232,7 @@ def check_rl_agent(Agent, env="continuous_state"):
     >>> from rlberry.utils import check_rl_agent
     >>> check_rl_agent(UCBVIAgent) # which does not return an error.
     """
-    check_agent_manager(Agent, env)  # check manager compatible.
-    check_seeding_agent(Agent, env)  # check reproducibility
-    check_fit_additive(Agent, env)
-    check_save_load(Agent, env)
+    check_agent_manager(agent, env)  # check manager compatible.
+    check_seeding_agent(agent, env)  # check reproducibility
+    check_fit_additive(agent, env)
+    check_save_load(agent, env)

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -49,7 +49,8 @@ def _fit_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
     train_env = _make_env(env)
     try:
-        agent = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED)
+        agent = AgentManager(agent, train_env, fit_budget=5, n_fit=1, seed=SEED,
+            init_kwargs=init_kwargs)
         agent.fit()
     except Exception as exc:
         raise RuntimeError("Agent not compatible with Agent Manager") from exc

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -11,7 +11,7 @@ SEED = 42
 
 def _make_env(env):
     """
-    help function to construct env from parameter env.
+    Help function to construct env from parameter env.
     """
     if isinstance(env, str):
         if env == "continuous_state":
@@ -36,13 +36,13 @@ def _fit_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
     """
     if init_kwargs is None:
         init_kwargs = {}
@@ -63,13 +63,13 @@ def check_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
     """
     _ = _fit_agent_manager(agent, env, init_kwargs=init_kwargs)
 
@@ -85,7 +85,6 @@ def check_agents_almost_equal(agent1, agent2, compare_using="policy", n_checks=5
 
     Parameters
     ----------
-
     agent1: rlberry Agent instance
         first agent to be compared
     agent2: rlberry Agent instance
@@ -129,13 +128,13 @@ def check_fit_additive(agent, env="continuous_state", init_kwargs=None):
 
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in ["continuous_state", "discrete_state"], default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in ["continuous_state", "discrete_state"], we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
     """
     if init_kwargs is None:
         init_kwargs = {}
@@ -163,16 +162,15 @@ def check_save_load(agent, env="continuous_state", init_kwargs=None):
     """
     Check that the agent save a non-empty file and can load.
 
-
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
     """
     if init_kwargs is None:
         init_kwargs = {}
@@ -206,13 +204,13 @@ def check_seeding_agent(agent, env=None, continuous_state=False,
 
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
     """
     agent1 = _fit_agent_manager(agent, env, init_kwargs=init_kwargs)
     agent2 = _fit_agent_manager(agent, env, init_kwargs=init_kwargs)
@@ -231,13 +229,13 @@ def check_rl_agent(agent, env="continuous_state", init_kwargs=None):
 
     Parameters
     ----------
-
-    Agent: rlberry agent module
+    agent: rlberry agent module
         Agent class to test.
-
     env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
         if tuple, env is the constructor and keywords of the env on which to test.
         if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
 
     Examples
     --------

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -99,7 +99,7 @@ def check_agents_almost_equal(agent1, agent2, compare_using="policy", n_checks=5
     results1 = []
     if compare_using == "policy":
         state = agent1.env.reset()
-    for f in range(5):
+    for f in range(n_checks):
         # do several tests if there is some randomness.
         if compare_using == "policy":
             results1.append(agent1.policy(state))
@@ -107,7 +107,7 @@ def check_agents_almost_equal(agent1, agent2, compare_using="policy", n_checks=5
             method_to_call = getattr(agent1, compare_using)
             results1.append(method_to_call())
     set_external_seed(SEED)
-    for f in range(5):
+    for f in range(n_checks):
         # do several tests if there is some randomness.
         if compare_using == "policy":
             result2 = agent2.policy(state)


### PR DESCRIPTION
Good afternoon!

As discussed in #133, we opted to add support for the `init_kwargs` argument for AgentManagers in the agent checks available at `rlberry/utils/check_agent.py`. The implementation is pretty straightforward, but I would like to mention two things:

1. I changed some variable names to conform to snake_case.
2. I discovered a bug when creating AgentManagers due to a recent reproducibility feature (issue #134).

Let me know what you think!