### PR TITLE
[MRG] Reduce warnings in rlberry

### DIFF
--- a/rlberry/agents/tests/test_replay.py
+++ b/rlberry/agents/tests/test_replay.py
@@ -21,7 +21,7 @@ def _get_filled_replay(max_replay_size):
     buffer.setup_entry("observations", np.float32)
     buffer.setup_entry("actions", np.uint32)
     buffer.setup_entry("rewards", np.float32)
-    buffer.setup_entry("dones", np.bool)
+    buffer.setup_entry("dones", bool)
 
     # Fill the replay buffer
     total_time = 0

--- a/rlberry/agents/torch/dqn/dqn.py
+++ b/rlberry/agents/torch/dqn/dqn.py
@@ -191,7 +191,7 @@ class DQNAgent(AgentWithSimplePolicy):
         self._replay_buffer.setup_entry("next_observations", np.float32)
         self._replay_buffer.setup_entry("actions", np.int32)
         self._replay_buffer.setup_entry("rewards", np.float32)
-        self._replay_buffer.setup_entry("dones", np.bool)
+        self._replay_buffer.setup_entry("dones", bool)
 
         # Counters
         self._total_timesteps = 0

--- a/rlberry/agents/utils/replay.py
+++ b/rlberry/agents/utils/replay.py
@@ -352,7 +352,7 @@ class ReplayBuffer:
         for tag in self.tags:
             batch_data[tag] = np.array(trajectories[tag], dtype=self._dtypes[tag])
 
-        batch_info["indices"] = np.array(all_indices, dtype=np.int)
+        batch_info["indices"] = np.array(all_indices, dtype=np.int32)
         batch_info["weights"] = weights
 
         batch = Batch(data=batch_data, info=batch_info)

--- a/rlberry/utils/tests/test_check.py
+++ b/rlberry/utils/tests/test_check.py
@@ -31,7 +31,7 @@ class DummyAgent:
         pass
 
 
-class TestAgent(ValueIterationAgent):
+class ReferenceAgent(ValueIterationAgent):
     def __init__(self, **kwargs):
         ValueIterationAgent.__init__(self, **kwargs)
 
@@ -72,8 +72,8 @@ def test_check_agent():
 def test_check_agent_manager_almost_equal():
     env = GridWorld
     env_kwargs = {}
-    agent1 = _fit_agent_manager(TestAgent, (env, env_kwargs)).agent_handlers[0]
-    agent2 = _fit_agent_manager(TestAgent, (env, env_kwargs)).agent_handlers[0]
+    agent1 = _fit_agent_manager(ReferenceAgent, (env, env_kwargs)).agent_handlers[0]
+    agent2 = _fit_agent_manager(ReferenceAgent, (env, env_kwargs)).agent_handlers[0]
     agent3 = _fit_agent_manager(UCBVIAgent, (env, env_kwargs)).agent_handlers[0]
     assert check_agents_almost_equal(agent1, agent2, compare_using="eval")
     assert not check_agents_almost_equal(agent1, agent3)


### PR DESCRIPTION
Hello again!

Today I noticed that we had a lot of warnings when running tests that could be easily solved. This PR solves a couple small things that drastically reduce the number of warnings I get:

1. Replace the deprecated numpy types `np.int` and `np.bool`;
2. Rename the `TestAgent` that was in `rlberry/utils/tests/test_check.py`. It seems that pytest was picking the class as being a test and then raising a warning because it was not.

There was another warning about creating a tensor from a list of numpy arrays in the REINFORCEAgent, but I decided to keep that as-is for now. The remaining warnings are caused by dependencies, namely `past` and `OpenGL`.