### PR TITLE
feat (agent and env) add get_params and set_params

### DIFF
--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -12,6 +12,8 @@ from rlberry.seeding import safe_reseed
 from rlberry.envs.utils import process_env
 from rlberry.utils.writers import DefaultWriter
 from typing import Optional
+import inspect
+from collections import defaultdict
 
 
 logger = logging.getLogger(__name__)
@@ -301,6 +303,92 @@ class Agent(ABC):
         obj.__dict__.clear()
         obj.__dict__.update(tmp_dict)
         return obj
+
+    @classmethod
+    def _get_param_names(cls):
+        """Get parameter names for the Model"""
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
+
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        init_signature = inspect.signature(init)
+        # Consider the constructor parameters excluding 'self'
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+
+        # Extract and sort argument names excluding 'self'
+        return sorted([p.name for p in parameters])
+
+    def get_params(self, deep=True):
+        """
+        Get parameters for this agent.
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this agent and
+            contained subobjects.
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        out = dict()
+        for key in self._get_param_names():
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params"):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
+    def set_params(self, **params):
+        """
+        Set the parameters of this agent.
+        The method works on simple estimators as well as on nested objects.
+        The latter have parameters of the form ``<component>__<parameter>``
+        so that it'spossible to update each component of a nested object.
+        Parameters
+        ----------
+        **params : dict
+            parameters.
+        Returns
+        -------
+        self : agent instance
+            agent instance.
+        """
+        if not params:
+            # Simple optimization to gain speed (inspect is slow)
+            return self
+        valid_params = self.get_params(deep=True)
+
+        nested_params = defaultdict(dict)  # grouped by prefix
+        for key, value in params.items():
+            key, delim, sub_key = key.partition("__")
+            if key not in valid_params:
+                raise ValueError(
+                    "Invalid parameter %s for agent %s. "
+                    "Check the list of available parameters "
+                    "with `agent.get_params().keys()`." % (key, self)
+                )
+
+            if delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        for key, sub_params in nested_params.items():
+            valid_params[key].set_params(**sub_params)
+
+        return self
 
 
 class AgentWithSimplePolicy(Agent):

--- a/rlberry/agents/torch/avec/avec_ppo.py
+++ b/rlberry/agents/torch/avec/avec_ppo.py
@@ -1,6 +1,7 @@
 import torch
 import logging
 import torch.nn as nn
+import inspect
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
@@ -115,6 +116,11 @@ class AVECPPOAgent(AgentWithSimplePolicy):
         device="cuda:best",
         **kwargs
     ):
+        # For all parameters, define self.param = param
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        values.pop("self")
+        for arg, val in values.items():
+            setattr(self, arg, val)
 
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
 
@@ -124,15 +130,6 @@ class AVECPPOAgent(AgentWithSimplePolicy):
                 self.env, **uncertainty_estimator_kwargs
             )
 
-        self.learning_rate = learning_rate
-        self.gamma = gamma
-        self.entr_coef = entr_coef
-        self.vf_coef = vf_coef
-        self.avec_coef = avec_coef
-        self.eps_clip = eps_clip
-        self.k_epochs = k_epochs
-        self.horizon = horizon
-        self.batch_size = batch_size
         self.device = choose_device(device)
 
         self.policy_net_kwargs = policy_net_kwargs or {}

--- a/rlberry/agents/torch/ppo/ppo.py
+++ b/rlberry/agents/torch/ppo/ppo.py
@@ -2,6 +2,7 @@ import numpy as np
 import torch
 import torch.nn as nn
 import logging
+import inspect
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
@@ -102,6 +103,11 @@ class PPOAgent(AgentWithSimplePolicy):
         **kwargs
     ):  # TODO: sort arguments
 
+        # For all parameters, define self.param = param
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        values.pop("self")
+        for arg, val in values.items():
+            setattr(self, arg, val)
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
 
         # bonus
@@ -112,17 +118,6 @@ class PPOAgent(AgentWithSimplePolicy):
             )
 
         # algorithm parameters
-        self.gamma = gamma
-        self.horizon = horizon
-
-        self.learning_rate = learning_rate
-        self.batch_size = batch_size
-        self.k_epochs = k_epochs
-        self.update_frequency = update_frequency
-
-        self.eps_clip = eps_clip
-        self.vf_coef = vf_coef
-        self.entr_coef = entr_coef
 
         # options
         # TODO: add reward normalization option

--- a/rlberry/agents/torch/reinforce/reinforce.py
+++ b/rlberry/agents/torch/reinforce/reinforce.py
@@ -1,5 +1,6 @@
 import logging
 import torch
+import inspect
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
@@ -70,15 +71,15 @@ class REINFORCEAgent(AgentWithSimplePolicy):
         device="cuda:best",
         **kwargs
     ):
+
+        # For all parameters, define self.param = param
+        args, _, _, values = inspect.getargvalues(inspect.currentframe())
+        values.pop("self")
+        for arg, val in values.items():
+            setattr(self, arg, val)
+
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
 
-        self.batch_size = batch_size
-        self.horizon = horizon
-        self.gamma = gamma
-        self.entr_coef = entr_coef
-        self.learning_rate = learning_rate
-        self.normalize = normalize
-        self.use_bonus_if_available = use_bonus_if_available
         self.device = choose_device(device)
 
         self.state_dim = self.env.observation_space.shape[0]

--- a/rlberry/envs/benchmarks/generalization/twinrooms.py
+++ b/rlberry/envs/benchmarks/generalization/twinrooms.py
@@ -40,6 +40,9 @@ class TwinRooms(RenderInterface2D, Model):
         Model.__init__(self)
         RenderInterface2D.__init__(self)
 
+        self.noise_room1 = noise_room1
+        self.noise_room2 = noise_room2
+
         self.observation_space = spaces.Box(
             low=np.array([0.0, 0.0]),
             high=np.array([2.0, 1.0]),

--- a/rlberry/envs/benchmarks/grid_exploration/nroom.py
+++ b/rlberry/envs/benchmarks/grid_exploration/nroom.py
@@ -76,6 +76,11 @@ class NRoom(GridWorld):
         self.reward_free = reward_free
         self.array_observation = array_observation
         self.nrooms = nrooms
+        self.room_size = room_size
+        self.success_probability = success_probability
+        self.remove_walls = remove_walls
+        self.initial_state_distribution = initial_state_distribution
+        self.include_traps = include_traps
 
         # Max number of rooms/columns per row
         self.max_rooms_per_row = 5

--- a/rlberry/envs/finite/chain.py
+++ b/rlberry/envs/finite/chain.py
@@ -22,6 +22,7 @@ class Chain(RenderInterface2D, FiniteMDP):
     def __init__(self, L=5, fail_prob=0.1):
         assert L >= 2
         self.L = L
+        self.fail_prob = fail_prob
 
         # transition probabilities
         P = np.zeros((L, 2, L))

--- a/rlberry/envs/interface/model.py
+++ b/rlberry/envs/interface/model.py
@@ -1,6 +1,8 @@
 import gym
 import numpy as np
 import logging
+import inspect
+from collections import defaultdict
 from rlberry.seeding import Seeder
 
 logger = logging.getLogger(__name__)
@@ -117,6 +119,92 @@ generative calls sample() method."
                 return False
             else:
                 raise
+
+    @classmethod
+    def _get_param_names(cls):
+        """Get parameter names for the Model"""
+        # fetch the constructor or the original constructor before
+        # deprecation wrapping if any
+        init = getattr(cls.__init__, "deprecated_original", cls.__init__)
+        if init is object.__init__:
+            # No explicit constructor to introspect
+            return []
+
+        # introspect the constructor arguments to find the model parameters
+        # to represent
+        init_signature = inspect.signature(init)
+        # Consider the constructor parameters excluding 'self'
+        parameters = [
+            p
+            for p in init_signature.parameters.values()
+            if p.name != "self" and p.kind != p.VAR_KEYWORD
+        ]
+
+        # Extract and sort argument names excluding 'self'
+        return sorted([p.name for p in parameters])
+
+    def get_params(self, deep=True):
+        """
+        Get parameters for this model.
+        Parameters
+        ----------
+        deep : bool, default=True
+            If True, will return the parameters for this model and
+            contained subobjects.
+        Returns
+        -------
+        params : dict
+            Parameter names mapped to their values.
+        """
+        out = dict()
+        for key in self._get_param_names():
+            value = getattr(self, key)
+            if deep and hasattr(value, "get_params"):
+                deep_items = value.get_params().items()
+                out.update((key + "__" + k, val) for k, val in deep_items)
+            out[key] = value
+        return out
+
+    def set_params(self, **params):
+        """
+        Set the parameters of this model.
+        The method works on simple estimators as well as on nested objects.
+        The latter have parameters of the form ``<component>__<parameter>``
+        so that it'spossible to update each component of a nested object.
+        Parameters
+        ----------
+        **params : dict
+            parameters.
+        Returns
+        -------
+        self : Model instance
+            Model instance.
+        """
+        if not params:
+            # Simple optimization to gain speed (inspect is slow)
+            return self
+        valid_params = self.get_params(deep=True)
+
+        nested_params = defaultdict(dict)  # grouped by prefix
+        for key, value in params.items():
+            key, delim, sub_key = key.partition("__")
+            if key not in valid_params:
+                raise ValueError(
+                    "Invalid parameter %s for environment %s. "
+                    "Check the list of available parameters "
+                    "with `env.get_params().keys()`." % (key, self)
+                )
+
+            if delim:
+                nested_params[key][sub_key] = value
+            else:
+                setattr(self, key, value)
+                valid_params[key] = value
+
+        for key, sub_params in nested_params.items():
+            valid_params[key].set_params(**sub_params)
+
+        return self
 
     @property
     def unwrapped(self):

--- a/rlberry/tests/test_agent.py
+++ b/rlberry/tests/test_agent.py
@@ -1,7 +1,7 @@
 import pytest
 import rlberry.agents as agents
 import rlberry.agents.torch as torch_agents
-from rlberry.utils.check_agent import check_rl_agent
+from rlberry.utils.check_agent import check_rl_agent, check_rlberry_agent
 from rlberry.agents.features import FeatureMap
 import numpy as np
 
@@ -50,11 +50,13 @@ CONTINUOUS_STATE_AGENTS = [
 ]
 
 
-@pytest.mark.parametrize("Agent", FINITE_MDP_AGENTS)
-def test_finite_state_agent(Agent):
-    check_rl_agent(Agent, env="discrete_state")
+@pytest.mark.parametrize("agent", FINITE_MDP_AGENTS)
+def test_finite_state_agent(agent):
+    check_rl_agent(agent, env="discrete_state")
+    check_rlberry_agent(agent, env="discrete_state")
 
 
-@pytest.mark.parametrize("Agent", CONTINUOUS_STATE_AGENTS)
-def test_continuous_state_agent(Agent):
-    check_rl_agent(Agent, env="continuous_state")
+@pytest.mark.parametrize("agent", CONTINUOUS_STATE_AGENTS)
+def test_continuous_state_agent(agent):
+    check_rl_agent(agent, env="continuous_state")
+    check_rlberry_agent(agent, env="continuous_state")

--- a/rlberry/tests/test_envs.py
+++ b/rlberry/tests/test_envs.py
@@ -1,4 +1,4 @@
-from rlberry.utils.check_env import check_env
+from rlberry.utils.check_env import check_env, check_rlberry_env
 from rlberry.envs import Acrobot
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.envs.benchmarks.generalization.twinrooms import TwinRooms
@@ -23,3 +23,4 @@ ALL_ENVS = [
 @pytest.mark.parametrize("Env", ALL_ENVS)
 def test_env(Env):
     check_env(Env())
+    check_rlberry_env(Env())

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -252,3 +252,32 @@ def check_rl_agent(agent, env="continuous_state", init_kwargs=None):
     check_seeding_agent(agent, env, init_kwargs=init_kwargs)  # check reproducibility
     check_fit_additive(agent, env, init_kwargs=init_kwargs)
     check_save_load(agent, env, init_kwargs=init_kwargs)
+
+
+def check_rlberry_agent(agent, env="continuous_state", init_kwargs=None):
+    """
+    Companion to check_rl_agent, contains additional tests. It is not mandatory
+    for an agent to satisfy this check but satisfying this check give access to
+    additional features in rlberry.
+
+    Parameters
+    ----------
+    agent: rlberry agent module
+        Agent class to test.
+    env: tuple (env_ctor, env_kwargs) or str in {"continuous_state", "discrete_state"}, default="continuous_state"
+        if tuple, env is the constructor and keywords of the env on which to test.
+        if str in {"continuous_state", "discrete_state"}, we use a default Benchmark environment.
+    init_kwargs : dict
+        Arguments required by the agent's constructor.
+
+    Examples
+    --------
+    >>> from rlberry.agents import UCBVIAgent
+    >>> from rlberry.utils import check_rl_agent
+    >>> check_rl_agent(UCBVIAgent) #
+    """
+    agent = _fit_agent_manager(agent, env, init_kwargs=init_kwargs).agent_handlers[0]
+    try:
+        params = agent.get_params()
+    except Exception:
+        raise RuntimeError("Fail to call get_params on the agent.")

--- a/rlberry/utils/check_env.py
+++ b/rlberry/utils/check_env.py
@@ -35,3 +35,21 @@ def check_env(env):
 
     # Modified check suite from gym
     check_gym_env(env)
+
+
+def check_rlberry_env(env):
+    """
+    Companion to check_env, contains additional tests. It is not mandatory
+    for an environment to satisfy this check but satisfying this check give access to
+    additional features in rlberry.
+
+    Parameters
+    ----------
+
+    env: gym.env or rlberry env
+        Environment that we want to check.
+    """
+    try:
+        params = env.get_params()
+    except Exception:
+        raise RuntimeError("Fail to call get_params on the environment.")


### PR DESCRIPTION
Copy of scikit-learn API get_params and set_params.

Example of use:

```
>>> env = Chain(fail_prob=0.8)
>>> env.get_params()
{'L': 5, 'fail_prob': 0.8}
>>> env.set_params(fail_prob=0.5)
>>> env.get_params()
{'L': 5, 'fail_prob': 0.5}
>>> env_ctor = env.__class__
>>> env_kwargs = env.get_params()
```

I implemented this in Agent and Model base classes. For these functions to work, all the parameters given to __init__ should become self.param. I changed all the agents and environments in rlberry to respect this rule. I also implemented a check/test for this and in the idea it should be an optional feature in the sense that if a user's custom agent does not support get_params, the main rlberry functionality should still work but there may be some missing small features. On the other hand all rlberry agents/env should support it ? (can be subject to discussion)

Related to a problem discussed with @omardrwch  and @riccardodv , with this we can properly construct the (ctor, kwargs) from a built env or agent.