### PR TITLE
(fix) Solve issue plot_writer_data and handle file as argument

### DIFF
--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -135,13 +135,14 @@ def read_writer_data(input_obj, tag, preprocess_func=None):
         else:
             take_last_date = True
     else:
-        take_last_date = False
-        for dir in input_obj:
-            files = list(Path(dir).iterdir())
-            if len(files) == 0:
-                raise RuntimeError(
-                    "One of the files in input_obj does not contain pickle files"
-                )
+        if not isinstance(input_obj[0], AgentManager):
+            take_last_date = False
+            for dir in input_obj:
+                files = list(Path(dir).iterdir())
+                if len(files) == 0:
+                    raise RuntimeError(
+                        "One of the files in input_obj does not contain pickle files"
+                    )
 
     if isinstance(input_obj[0], AgentManager):
         agent_manager_list = input_obj

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -102,11 +102,17 @@ def read_writer_data(data_source, tag, preprocess_func=None):
 
     Parameters
     ----------
-    data_source : AgentManager, or list of AgentManager or directory or list of directories
-        If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
+    data_source : :class:`~rlberry.manager.AgentManager`, or list of :class:`~rlberry.manager.AgentManager` or str or list of str
+        - If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
 
-        If directory, load the data from the directory of the latest experiment in date.
-        If list of directories, load the data from these directories.
+        - If str, the string must be the string path of a directory,  each
+        subdirectory of this directory must contain pickle files.
+        Load the data from the directory of the latest experiment in date.
+        This str should be equal to the value of the `output_dir` parameter in
+            :class:`~rlberry.manager.AgentManager`.
+
+        - If list of str, each string must be a directory containing pickle files.
+            Load the data from these pickle files.
 
         Note: the agent's save function must save its writer at the key `_writer`.
         This is the default for rlberry agents.
@@ -273,11 +279,17 @@ def plot_writer_data(
 
     Parameters
     ----------
-    data_source : AgentManager, or list of AgentManager or directory or list of directories
-        If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
+    data_source : :class:`~rlberry.manager.AgentManager`, or list of :class:`~rlberry.manager.AgentManager` or str or list of str
+        - If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
 
-        If directory, load the data from the directory of the latest experiment in date.
-        If list of directories, load the data from these directories.
+        - If str, the string must be the string path of a directory,  each
+        subdirectory of this directory must contain pickle files.
+        load the data from the directory of the latest experiment in date.
+        This str should be equal to the value of the `output_dir` parameter in
+        :class:`~rlberry.manager.AgentManager`.
+
+        - If list of str, each string must be a directory containing pickle files
+        load the data from these pickle files.
 
         Note: the agent's save function must save its writer at the key `_writer`.
         This is the default for rlberry agents.

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -95,14 +95,14 @@ def evaluate_agents(
     return output
 
 
-def read_writer_data(input_obj, tag, preprocess_func=None):
+def read_writer_data(data_source, tag, preprocess_func=None):
     """
     Given a list of AgentManager or a folder, read data (corresponding to info) obtained in each episode.
     The dictionary returned by agents' .fit() method must contain a key equal to `info`.
 
     Parameters
     ----------
-    input_obj : AgentManager, or list of AgentManager or directory or list of directories
+    data_source : AgentManager, or list of AgentManager or directory or list of directories
         If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
 
         If directory, load the data from the directory of the latest experiment in date.
@@ -129,25 +129,25 @@ def read_writer_data(input_obj, tag, preprocess_func=None):
     """
     input_dir = None
 
-    if not isinstance(input_obj, list):
-        if isinstance(input_obj, AgentManager):
-            input_obj = [input_obj]
+    if not isinstance(data_source, list):
+        if isinstance(data_source, AgentManager):
+            data_source = [data_source]
         else:
             take_last_date = True
     else:
-        if not isinstance(input_obj[0], AgentManager):
+        if not isinstance(data_source[0], AgentManager):
             take_last_date = False
-            for dir in input_obj:
+            for dir in data_source:
                 files = list(Path(dir).iterdir())
                 if len(files) == 0:
                     raise RuntimeError(
-                        "One of the files in input_obj does not contain pickle files"
+                        "One of the files in data_source does not contain pickle files"
                     )
 
-    if isinstance(input_obj[0], AgentManager):
-        agent_manager_list = input_obj
+    if isinstance(data_source[0], AgentManager):
+        agent_manager_list = data_source
     else:
-        input_dir = input_obj
+        input_dir = data_source
 
     if isinstance(tag, str):
         tags = [tag]
@@ -257,7 +257,7 @@ def _load_data(agent_folder, dir_name):
 
 
 def plot_writer_data(
-    input_obj,
+    data_source,
     tag,
     xtag=None,
     ax=None,
@@ -273,7 +273,7 @@ def plot_writer_data(
 
     Parameters
     ----------
-    input_obj : AgentManager, or list of AgentManager or directory or list of directories
+    data_source : AgentManager, or list of AgentManager or directory or list of directories
         If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
 
         If directory, load the data from the directory of the latest experiment in date.
@@ -312,7 +312,7 @@ def plot_writer_data(
         ylabel = "value"
     else:
         ylabel = tag
-    processed_df = read_writer_data(input_obj, tag, preprocess_func)
+    processed_df = read_writer_data(data_source, tag, preprocess_func)
     # add column with xtag, if given
     if xtag is not None:
         df_xtag = pd.DataFrame(processed_df[processed_df["tag"] == xtag])

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -1,3 +1,4 @@
+import pytest
 import tempfile
 import os
 import numpy as np
@@ -18,59 +19,90 @@ class VIAgent(UCBVIAgent):
         self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
 
 
-def test_plot_writer_data():
+def _create_and_fit_agent_manager(output_dir, outdir_id_style):
+    env_ctor = GridWorld
+    env_kwargs = dict(nrows=2, ncols=2, reward_at={(1, 1): 0.1, (2, 2): 1.0})
+
+    manager = AgentManager(
+        VIAgent,
+        (env_ctor, env_kwargs),
+        fit_budget=10,
+        n_fit=3,
+        output_dir=output_dir,
+        outdir_id_style=outdir_id_style,
+    )
+    manager.fit()
+    manager.save()
+    return manager
+
+
+def _compute_reward(rewards):
+    return np.cumsum(rewards)
+
+
+@pytest.mark.parametrize("outdir_id_style", [None, "unique", "timestamp"])
+def test_plot_writer_data_with_manager_input(outdir_id_style):
     with tempfile.TemporaryDirectory() as tmpdirname:
-        env_ctor = GridWorld
-        env_kwargs = dict(nrows=2, ncols=2, reward_at={(1, 1): 0.1, (2, 2): 1.0})
-
-        agent = AgentManager(
-            VIAgent,
-            (env_ctor, env_kwargs),
-            fit_budget=10,
-            n_fit=3,
-            output_dir=tmpdirname + "/rlberry_data",
-        )
-        agent.fit()
-
-        def compute_reward(rewards):
-            return np.cumsum(rewards)
-
+        output_dir = tmpdirname + "/rlberry_data"
+        manager = _create_and_fit_agent_manager(output_dir, outdir_id_style)
         os.system("ls " + tmpdirname + "/rlberry_data/manager_data")
 
-        # Plot of the cumulative reward.
+        # Plot of the cumulative reward
+        data_source = manager
         output = plot_writer_data(
-            agent,
+            data_source,
             tag="reward",
-            preprocess_func=compute_reward,
+            preprocess_func=_compute_reward,
             title="Cumulative Reward",
             show=False,
             savefig_fname=tmpdirname + "/test.png",
         )
         assert (
             os.path.getsize(tmpdirname + "/test.png") > 1000
-        ), "plot_writer_data output an empty image"
+        ), "plot_writer_data saved an empty image"
         assert len(output) > 1
 
-        output2 = plot_writer_data(
-            tmpdirname + "/rlberry_data",
+
+@pytest.mark.parametrize("outdir_id_style", ["timestamp"])
+def test_plot_writer_data_with_directory_input(outdir_id_style):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        output_dir = tmpdirname + "/rlberry_data"
+        manager = _create_and_fit_agent_manager(output_dir, outdir_id_style)
+        del manager
+
+        os.system("ls " + tmpdirname + "/rlberry_data/manager_data")
+
+        #
+        # Single directory
+        #
+
+        data_source = output_dir
+        output = plot_writer_data(
+            data_source,
             tag="reward",
-            preprocess_func=compute_reward,
+            preprocess_func=_compute_reward,
             title="Cumulative Reward",
             show=False,
             savefig_fname=tmpdirname + "/test.png",
         )
-        assert np.all(output.shape == output2.shape)
+        assert (
+            os.path.getsize(tmpdirname + "/test.png") > 1000
+        ), "plot_writer_data saved an empty image"
+        assert len(output) > 1
 
         list_dirs = list(Path(tmpdirname + "/rlberry_data/manager_data").iterdir())
         list_dirs = [str(dir) for dir in list_dirs]
 
-        output3 = plot_writer_data(
+        #
+        # List of directories
+        #
+        output_with_list_dirs = plot_writer_data(
             list_dirs,
             tag="reward",
-            preprocess_func=compute_reward,
+            preprocess_func=_compute_reward,
             title="Cumulative Reward",
             show=False,
             savefig_fname=tmpdirname + "/test.png",
         )
 
-        assert np.all(output.shape == output3.shape)
+        assert np.all(output.shape == output_with_list_dirs.shape)

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -1,6 +1,8 @@
 import tempfile
 import os
 import numpy as np
+from pathlib import Path
+
 
 from rlberry.wrappers import WriterWrapper
 from rlberry.envs import GridWorld
@@ -46,5 +48,29 @@ def test_plot_writer_data():
         )
         assert (
             os.path.getsize(tmpdirname + "/test.png") > 1000
-        )  # check that the file is not empty
+        ), "plot_writer_data output an empty image"
         assert len(output) > 1
+
+        output2 = plot_writer_data(
+            tmpdirname + "/rlberry_data",
+            tag="reward",
+            preprocess_func=compute_reward,
+            title="Cumulative Reward",
+            show=False,
+            savefig_fname=tmpdirname + "/test.png",
+        )
+        assert np.all(output.shape == output2.shape)
+
+        list_dirs = list(Path(tmpdirname + "/rlberry_data/manager_data").iterdir())
+        list_dirs = [str(dir) for dir in list_dirs]
+
+        output3 = plot_writer_data(
+            list_dirs,
+            tag="reward",
+            preprocess_func=compute_reward,
+            title="Cumulative Reward",
+            show=False,
+            savefig_fname=tmpdirname + "/test.png",
+        )
+
+        assert np.all(output.shape == output3.shape)


### PR DESCRIPTION
Should solve Issue  #151 

read_writer_data and plot_writer_data now take as argument 
```
    input_obj : AgentManager, or list of AgentManager or directory or list of directories
        If AgentManager or list of AgentManager, load data from it (the agents must be fitted).
        If directory, load the data from the directory of the latest experiment in date.
        If list of directories, load the data from these directories.
```

Now these functions take as input 

- a fitted agent and in this case the data are plotted from memory, the functions will not use the pickle files.
- a directory containing subdirectories containing pickles in which case it will plot the pickles corresponding to the last experiment
- a list of directories containing pickles, in which case it will plot the pickles.

Question @omardrwch : I think we may want to rethink the default `rlberry_data` name of the directory. Would it make sense for example to use `rlberry_data/name_of_script/` instead ? The idea is that one directory should be for one script (= one experiment)