### PR TITLE
[WIP] feat (reproductibility) scripts to freeze a python install in a compressed virtual env

### DIFF
--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -41,7 +41,7 @@ $new_pip install wheel
 if [[ -f "$rlberry_source/setup.py" ]]; then
     echo "using custom rlberry source"
 
-    $new_pip install -r $rlberry_source/requirements.txt
+    cat $rlberry_source/requirements.txt | xargs -n 1 $new_pip install
     $new_pip install $rlberry_source
 else
     echo "using last pip version rlberry"

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+NAME=$1
+SCRIPT_PATH=${@:2}
+
+
+usage="$(basename "$0") [-h]  NAME FILE1 FILE2...
+
+FREEZE an environment and a script in a tar archive
+the NAME is a string that will be used as name for the archive file
+The Files must be a python files, glob accepted
+"
+
+Run(){
+cat << EOF > get_rlberry_source.py
+import rlberry
+from pathlib import Path
+
+rlberry_source = str(Path(rlberry.__file__).parents[1])
+print(rlberry_source)
+EOF
+
+rlberry_source=$(python get_rlberry_source.py 2>&1)
+
+echo $rlberry_source
+
+FREEZE_PATH=freeze_dir
+
+# ADDITIONAL_DEPS={}
+
+echo "Creating the environment"
+
+python3 -m venv $FREEZE_PATH
+
+new_pip=$FREEZE_PATH/bin/pip3
+
+echo "Installing rlberry and necessary deps"
+
+$new_pip install wheel
+$new_pip install -r $rlberry_source/requirements.txt
+$new_pip install $rlberry_source
+
+echo "Packing the env and creating archives"
+
+venv-pack -p $FREEZE_PATH -o $FREEZE_PATH.tar.gz
+
+tar -cf $NAME.tar $FREEZE_PATH.tar.gz $SCRIPT_PATH
+
+read -r -p "Do you want to clean the temporary files? (Y/N): " answer
+if [ $answer = "Y" ]
+then
+    /bin/rm $FREEZE_PATH.tar.gz
+    /bin/rm -r $FREEZE_PATH
+    /bin/rm -r get_rlberry_source.py
+fi
+}
+
+case "$1" in
+     -h) echo "$usage"
+       exit
+       ;;
+     "") echo "Missing an argument"
+       echo " "
+       echo "$usage" >&2
+       exit 1
+       ;;
+    -*)
+      echo "Error: Unknown option: $1" >&2
+      echo "$usage" >&2
+      exit 1
+      ;;
+     *)
+     Run
+      ;;
+esac

--- a/scripts/freeze.sh
+++ b/scripts/freeze.sh
@@ -22,7 +22,7 @@ EOF
 
 rlberry_source=$(python get_rlberry_source.py 2>&1)
 
-echo $rlberry_source
+
 
 FREEZE_PATH=freeze_dir
 
@@ -37,14 +37,24 @@ new_pip=$FREEZE_PATH/bin/pip3
 echo "Installing rlberry and necessary deps"
 
 $new_pip install wheel
-$new_pip install -r $rlberry_source/requirements.txt
-$new_pip install $rlberry_source
+
+if [[ -f "$rlberry_source/setup.py" ]]; then
+    echo "using custom rlberry source"
+
+    $new_pip install -r $rlberry_source/requirements.txt
+    $new_pip install $rlberry_source
+else
+    echo "using last pip version rlberry"
+    $new_pip install git+https://github.com/rlberry-py/rlberry.git#egg=rlberry[torch_agents]
+fi
 
 echo "Packing the env and creating archives"
 
 venv-pack -p $FREEZE_PATH -o $FREEZE_PATH.tar.gz
 
-tar -cf $NAME.tar $FREEZE_PATH.tar.gz $SCRIPT_PATH
+python3 --version > python_version
+
+tar -cf $NAME.tar $FREEZE_PATH.tar.gz $SCRIPT_PATH python_version
 
 read -r -p "Do you want to clean the temporary files? (Y/N): " answer
 if [ $answer = "Y" ]
@@ -52,6 +62,7 @@ then
     /bin/rm $FREEZE_PATH.tar.gz
     /bin/rm -r $FREEZE_PATH
     /bin/rm -r get_rlberry_source.py
+    /bin/rm python_version
 fi
 }
 

--- a/scripts/unfreeze.sh
+++ b/scripts/unfreeze.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+usage="$(basename "$0") [-h] FILE
+
+Unfreeze a frozen environment and a script
+The FILE must be a tar file constructed using freeze.sh
+"
+FROZEN_FILE=$1
+FREEZE_PATH=freeze_dir
+
+Run(){
+
+script=$(tar -tf test.tar | grep -v freeze_dir)
+
+
+echo "decompressing the frozen env"
+
+
+tar -xf $FROZEN_FILE >/dev/null 2>&1
+mkdir env_dir
+tar -zxvf $FREEZE_PATH.tar.gz -C env_dir >/dev/null 2>&1
+/bin/rm $FREEZE_PATH.tar.gz
+
+echo "the unfrozen scripts are " $script
+echo "the unfrozen virtual env is env_dir"
+
+echo "you can activate the environment with 'source env_dir/bin/activate'"
+
+source env_dir/bin/activate
+}
+
+
+case "$1" in
+     -h) echo "$usage"
+       exit
+       ;;
+     "") echo "Missing an argument"
+       echo " "
+       echo "$usage" >&2
+       exit 1
+       ;;
+    -*)
+      echo "Error: Unknown option: $1" >&2
+      echo "$usage" >&2
+      exit 1
+      ;;
+     *)
+     Run
+      ;;
+esac

--- a/scripts/unfreeze.sh
+++ b/scripts/unfreeze.sh
@@ -10,7 +10,7 @@ FREEZE_PATH=freeze_dir
 
 Run(){
 
-script=$(tar -tf test.tar | grep -v freeze_dir)
+script=$(tar -tf $FROZEN_FILE | grep -v freeze_dir)
 
 
 echo "decompressing the frozen env"
@@ -23,6 +23,10 @@ tar -zxvf $FREEZE_PATH.tar.gz -C env_dir >/dev/null 2>&1
 
 echo "the unfrozen scripts are " $script
 echo "the unfrozen virtual env is env_dir"
+echo "the python version used in this virtual env is "
+cat python_version
+/bin/rm python_version
+echo "make sure that this version of python is installed in your system to be able to use this environment"
 
 echo "you can activate the environment with 'source env_dir/bin/activate'"
 


### PR DESCRIPTION
In this PR I introduce two scripts : `freeze` and `unfreeze`. 

- the script `freeze name files.py` will locate rlberry (if it is a git install, use this, if not use pypi rlberry), make a new virtual environment, install everything in the virtual env and compress everything. Then, it will create a tar archive with this compressed env + the files.py + info on python version, effectively saving (freezing) your work. 
- the script `unfreeze name.tar` will uncompress everything and give some information about what has been uncompressed.

size of compressed frozen env is 910Mo, which is mainly due to torch.

The script only depends on some pip library named `venv-pack`. I did not use conda  because it is not everyone that uses  conda, on the other hand `venv` is a part of python install so everyone has it.

Limitations:

- For now, only work on Linux, I used bash. We would have to use python maybe to have something crossed platform. 
- For now, does not support additional dependencies but it should not be difficult to implement.
- I don't know why but the installation of PyOpenGL-accelerate bugs in the virtualenv installation. The other libraries work fine and PyOpenGL-accelerate is not essential so for now, it is ok to do without it.
- A virtual environment does not encapsulate the python executable, hence when unfreezing, we must make sure that the right version of python is installed on your system.
- If one freezes several times several environments, this may take too much space. Maybe we could use some incremental tar utilities that only backup changes without rewriting the whole env every time.

