### PR TITLE
[MRG] Improve RL Agent Checks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ PyOpenGL_accelerate==3.1.5
 pyvirtualdisplay
 torch>=1.6.0
 stable-baselines3
+tensorboard

--- a/rlberry/agents/tests/test_stable_baselines.py
+++ b/rlberry/agents/tests/test_stable_baselines.py
@@ -4,35 +4,17 @@ from stable_baselines3 import A2C
 
 from rlberry.envs import gym_make
 from rlberry.agents import StableBaselinesAgent
-from rlberry.utils.check_agent import (
-    check_agent_manager,
-    check_seeding_agent,
-    check_save_load,
-)
-
-
-def _sb3_check_rl_agent(agent_cls, env, init_kwargs=None):
-    """
-    Check that an RL agent can be instantiated and fit.
-
-    Note
-    ----
-    Does not check that the fit is additive, because that doesn't seem to be
-    always the case with StableBaselines3.
-    """
-    check_agent_manager(agent_cls, env, init_kwargs=init_kwargs)
-    check_seeding_agent(agent_cls, env, init_kwargs=init_kwargs)
-    check_save_load(agent_cls, env, init_kwargs=init_kwargs)
+from rlberry.utils.check_agent import check_rl_agent
 
 
 def test_sb3_agent():
     # Test only one algorithm per action space type
-    _sb3_check_rl_agent(
+    check_rl_agent(
         StableBaselinesAgent,
         env=(gym_make, {"id": "Pendulum-v0"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
     )
-    _sb3_check_rl_agent(
+    check_rl_agent(
         StableBaselinesAgent,
         env=(gym_make, {"id": "CartPole-v1"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
@@ -42,7 +24,7 @@ def test_sb3_agent():
 def test_sb3_tensorboard_log():
     # Test tensorboard support
     with tempfile.TemporaryDirectory() as tmpdir:
-        _sb3_check_rl_agent(
+        check_rl_agent(
             StableBaselinesAgent,
             env=(gym_make, {"id": "Pendulum-v0"}),
             init_kwargs={

--- a/rlberry/agents/tests/test_stable_baselines.py
+++ b/rlberry/agents/tests/test_stable_baselines.py
@@ -11,12 +11,12 @@ def test_sb3_agent():
     # Test only one algorithm per action space type
     check_rl_agent(
         StableBaselinesAgent,
-        env=(gym_make, {"id": "Pendulum-v0"}),
+        env=(gym_make, {"id": "Pendulum"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
     )
     check_rl_agent(
         StableBaselinesAgent,
-        env=(gym_make, {"id": "CartPole-v1"}),
+        env=(gym_make, {"id": "CartPole"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
     )
 
@@ -26,7 +26,7 @@ def test_sb3_tensorboard_log():
     with tempfile.TemporaryDirectory() as tmpdir:
         check_rl_agent(
             StableBaselinesAgent,
-            env=(gym_make, {"id": "Pendulum-v0"}),
+            env=(gym_make, {"id": "Pendulum"}),
             init_kwargs={
                 "algo_cls": A2C,
                 "policy": "MlpPolicy",

--- a/rlberry/agents/tests/test_stable_baselines.py
+++ b/rlberry/agents/tests/test_stable_baselines.py
@@ -11,12 +11,12 @@ def test_sb3_agent():
     # Test only one algorithm per action space type
     check_rl_agent(
         StableBaselinesAgent,
-        env=(gym_make, {"id": "Pendulum"}),
+        env=(gym_make, {"id": "Pendulum-v1"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
     )
     check_rl_agent(
         StableBaselinesAgent,
-        env=(gym_make, {"id": "CartPole"}),
+        env=(gym_make, {"id": "CartPole-v1"}),
         init_kwargs={"algo_cls": A2C, "policy": "MlpPolicy", "verbose": 1},
     )
 
@@ -26,7 +26,7 @@ def test_sb3_tensorboard_log():
     with tempfile.TemporaryDirectory() as tmpdir:
         check_rl_agent(
             StableBaselinesAgent,
-            env=(gym_make, {"id": "Pendulum"}),
+            env=(gym_make, {"id": "Pendulum-v1"}),
             init_kwargs={
                 "algo_cls": A2C,
                 "policy": "MlpPolicy",

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -140,17 +140,14 @@ def check_fit_additive(agent, env="continuous_state", init_kwargs=None):
     """
     if init_kwargs is None:
         init_kwargs = {}
+    init_kwargs["seeder"] = SEED
     train_env = _make_env(env)
 
-    agent1 = AgentManager(
-        agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
-    )
+    agent1 = agent(train_env, **init_kwargs)
     agent1.fit(3)
     agent1.fit(3)
 
-    agent2 = AgentManager(
-        agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
-    )
+    agent2 = agent(train_env, **init_kwargs)
     agent2.fit(6)
 
     result = check_agents_almost_equal(

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -143,16 +143,16 @@ def check_fit_additive(agent, env="continuous_state", init_kwargs=None):
     init_kwargs["seeder"] = SEED
     train_env = _make_env(env)
 
+    set_external_seed(SEED)
     agent1 = agent(train_env, **init_kwargs)
-    agent1.fit(3)
-    agent1.fit(3)
+    agent1.fit(10)
+    agent1.fit(10)
 
+    set_external_seed(SEED)
     agent2 = agent(train_env, **init_kwargs)
-    agent2.fit(6)
+    agent2.fit(20)
 
-    result = check_agents_almost_equal(
-        agent1.agent_handlers[0], agent2.agent_handlers[0]
-    )
+    result = check_agents_almost_equal(agent1, agent2)
 
     assert (
         result


### PR DESCRIPTION
Hello,

This PR improves the RL Agent Checks by *not* using the AgentManager when doing additive fits checks. 

As it turns out, using the agent manager can cause problems with the torch RNG - which this PR aims to solve by using only the Agent classes.

Additionally, I had to change a few things on the StableBaselinesAgent so it works with the new test, but it should be working well now :)
