### PR TITLE
[WIP] Make sure rlberry.agents works when StableBaselines3 is not installed

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -42,7 +42,7 @@ Basic Agents
    :toctree: generated/
    :template: class.rst
 
-   agents.StableBaselinesAgent
+   agents.stable_baselines.StableBaselinesAgent
 
 
 Torch Agents (experimental)

--- a/rlberry/agents/__init__.py
+++ b/rlberry/agents/__init__.py
@@ -1,3 +1,7 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
 # Interfaces
 from .agent import Agent
 from .agent import AgentWithSimplePolicy
@@ -15,4 +19,8 @@ from .rlsvi import RLSVIAgent
 from .ucbvi import UCBVIAgent
 
 # Importing tools
-from .stable_baselines import StableBaselinesAgent
+try:
+    from .stable_baselines import StableBaselinesAgent
+except ModuleNotFoundError:
+    logger.warn("stable_baselines3 not installed. Skipping StableBaselinesAgent.")
+    pass

--- a/rlberry/agents/__init__.py
+++ b/rlberry/agents/__init__.py
@@ -1,7 +1,3 @@
-import logging
-
-logger = logging.getLogger(__name__)
-
 # Interfaces
 from .agent import Agent
 from .agent import AgentWithSimplePolicy
@@ -17,10 +13,3 @@ from .optql import OptQLAgent
 from .psrl import PSRLAgent
 from .rlsvi import RLSVIAgent
 from .ucbvi import UCBVIAgent
-
-# Importing tools
-try:
-    from .stable_baselines import StableBaselinesAgent
-except ModuleNotFoundError:
-    logger.warn("stable_baselines3 not installed. Skipping StableBaselinesAgent.")
-    pass

--- a/rlberry/agents/tests/test_stable_baselines.py
+++ b/rlberry/agents/tests/test_stable_baselines.py
@@ -3,7 +3,7 @@ import tempfile
 from stable_baselines3 import A2C
 
 from rlberry.envs import gym_make
-from rlberry.agents import StableBaselinesAgent
+from rlberry.agents.stable_baselines import StableBaselinesAgent
 from rlberry.utils.check_agent import (
     check_agent_manager,
     check_seeding_agent,


### PR DESCRIPTION
As per #166, we introduced this bug with the StableBaselinesAgent.

I just added a guard that throws a warning if it can't find the library - let me know what you think.