### PR TITLE
[MRG] AgentManager: data sharing among threads

### DIFF
--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -43,7 +43,7 @@ class Agent(ABC):
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
         Used by :class:`~rlberry.manager.AgentManager`.
-    _thread_shared_data: dict, optional
+    _thread_shared_data : dict, optional
         Used by :class:`~rlberry.manager.AgentManager` to share data across Agent
         instances created in different threads.
     **kwargs : dict

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -43,6 +43,9 @@ class Agent(ABC):
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
         Used by :class:`~rlberry.manager.AgentManager`.
+    _thread_shared_data: dict, optional
+        Used by :class:`~rlberry.manager.AgentManager` to share data across Agent
+        instances created in different threads.
     **kwargs : dict
         Classes that implement this interface must send ``**kwargs``
         to :code:`Agent.__init__()`.
@@ -68,6 +71,8 @@ class Agent(ABC):
     unique_id : str
         Unique identifier for the agent instance. Can be used, for example,
         to create files/directories for the agent to log data safely.
+    thread_shared_data : dict
+        Data shared by agent instances among different threads.
     """
 
     name = ""
@@ -81,6 +86,7 @@ class Agent(ABC):
         output_dir: Optional[str] = None,
         _execution_metadata: Optional[metadata_utils.ExecutionMetadata] = None,
         _default_writer_kwargs: Optional[dict] = None,
+        _thread_shared_data: Optional[dict] = None,
         **kwargs,
     ):
         # Check if wrong parameters have been sent to an agent.
@@ -111,6 +117,9 @@ class Agent(ABC):
         self._output_dir = output_dir or f"output_{self._unique_id}"
         self._output_dir = Path(self._output_dir)
 
+        # shared data among threads
+        self._thread_shared_data = _thread_shared_data
+
     @property
     def writer(self):
         return self._writer
@@ -126,6 +135,12 @@ class Agent(ABC):
     @property
     def rng(self):
         return self.seeder.rng
+
+    @property
+    def thread_shared_data(self):
+        if self._thread_shared_data is None:
+            return dict()
+        return self._thread_shared_data
 
     @abstractmethod
     def fit(self, budget: int, **kwargs):

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -107,6 +107,7 @@ class StableBaselinesAgent(AgentWithSimplePolicy):
         "output_dir",
         "_execution_metadata",
         "_default_writer_kwargs",
+        "_thread_shared_data",
     ]
 
     def __init__(

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -302,9 +302,9 @@ class AgentManager:
 
         # shared data
         self.thread_shared_data = thread_shared_data  # do not deepcopy for sharing!
-        if parallelization == "process" and thread_shared_data is not None:
+        if parallelization != "thread" and thread_shared_data is not None:
             logger.warning(
-                "Using thread_shared_data and parallelization='process'"
+                f"Using thread_shared_data and parallelization = {parallelization}"
                 " in AgentManager does *not* share data among Agent instances!"
                 " Each process will have its copy of thread_shared_data."
             )

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -224,6 +224,9 @@ class AgentManager:
         ``init_kwargs_per_instance`` will be used.
         Attention: parameters that are passed individually to each agent instance
         cannot be optimized in the method optimize_hyperparams().
+    thread_shared_data : dict, optional
+        Data to be shared among agent instances in different threads.
+        If parallelization='process', data will be copied instead of shared.
 
 
     Attributes
@@ -253,6 +256,7 @@ class AgentManager:
         outdir_id_style="timestamp",
         default_writer_kwargs=None,
         init_kwargs_per_instance=None,
+        thread_shared_data=None,
     ):
         # agent_class should only be None when the constructor is called
         # by the class method AgentManager.load(), since the agent class
@@ -295,6 +299,15 @@ class AgentManager:
             eval_env = deepcopy(train_env)
 
         self._eval_env = eval_env
+
+        # shared data
+        self.thread_shared_data = thread_shared_data  # do not deepcopy for sharing!
+        if parallelization == "process" and thread_shared_data is not None:
+            logger.warning(
+                "Using thread_shared_data and parallelization='process'"
+                " in AgentManager does *not* share data among Agent instances!"
+                " Each process will have its copy of thread_shared_data."
+            )
 
         # check kwargs
         fit_kwargs = fit_kwargs or {}
@@ -404,7 +417,10 @@ class AgentManager:
         init_seeders = self.seeder.spawn(self.n_fit, squeeze=False)
         self.init_kwargs = []
         for ii in range(self.n_fit):
+            # deepcopy base_init_kwargs
             kwargs_ii = deepcopy(self._base_init_kwargs)
+            # include shared data, without deep copy!
+            kwargs_ii["_thread_shared_data"] = self.thread_shared_data
             kwargs_ii.update(
                 dict(
                     env=self.train_env,
@@ -935,6 +951,7 @@ class AgentManager:
                 :n_fit
             ],  # init_kwargs_per_instance only for the first n_fit instances
             custom_eval_function=custom_eval_function,
+            thread_shared_data=self.thread_shared_data,
         )
 
         try:
@@ -1092,6 +1109,7 @@ def _optuna_objective(
     fit_fraction,
     init_kwargs_per_instance,
     custom_eval_function,
+    thread_shared_data,
 ):
     kwargs = deepcopy(base_init_kwargs)
 
@@ -1118,6 +1136,7 @@ def _optuna_objective(
         enable_tensorboard=False,
         outdir_id_style="unique",
         init_kwargs_per_instance=init_kwargs_per_instance,
+        thread_shared_data=thread_shared_data,
     )
 
     if disable_evaluation_writers:

--- a/rlberry/manager/tests/test_shared_data.py
+++ b/rlberry/manager/tests/test_shared_data.py
@@ -1,0 +1,40 @@
+import pytest
+import numpy as np
+from rlberry.agents import Agent
+from rlberry.manager import AgentManager
+
+
+class DummyAgent(Agent):
+    def __init__(self, **kwargs):
+        Agent.__init__(self, **kwargs)
+        self.name = "DummyAgent"
+        self.shared_data_id = id(self.thread_shared_data)
+
+    def fit(self, budget, **kwargs):
+        del budget, kwargs
+
+    def eval(self, **kwargs):
+        del kwargs
+        return self.shared_data_id
+
+
+@pytest.mark.parametrize("paralellization", ["thread", "process"])
+def test_data_sharing(paralellization):
+    shared_data = dict(X=np.arange(10))
+    manager = AgentManager(
+        agent_class=DummyAgent,
+        fit_budget=-1,
+        n_fit=4,
+        parallelization=paralellization,
+        thread_shared_data=shared_data,
+    )
+    manager.fit()
+    data_ids = [agent.eval() for agent in manager.get_agent_instances()]
+    unique_data_ids = list(set(data_ids))
+    if paralellization == "thread":
+        # id() is unique for each object: make sure that shared data have same id
+        assert len(unique_data_ids) == 1
+    else:
+        # when using processes, make sure that data is copied and each instance
+        # has its own data id
+        assert len(unique_data_ids) == manager.n_fit


### PR DESCRIPTION
This PR makes it possible to share data among agent instances created by `AgentManager` in different threads, by sending a `thread_shared_data` dictionary to `AgentManager`. 

A warning is logged if `thread_shared_data`  is given but `parallelization = "process"`, in which case data is copied in each process, instead of being shared.