### PR TITLE
feat (manager) Print information statistics in AgentManager

### DIFF
--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1095,6 +1095,7 @@ class AgentManager:
                 [df, pd.DataFrame({tags[i]: [values[i]] for i in range(len(tags))})],
                 ignore_index=True,
             )
+
         print("Statistics of writer data collected on last iteration of each fit.")
         print("Means of values over %d fits:" % (len(df)))
         print(df.mean())
@@ -1128,10 +1129,10 @@ class AgentManager:
         print("Statistics of the evaluation of fitted agents")
         eval_values = []
         for idx in range(len(df)):
+            logger.info("Evaluating agent " + str(idx))
             eval_values.append(
                 np.mean(self.eval_agents(n_evaluations, agent_id=idx, verbose=False))
             )
-            logger.info("Evaluating agent " + str(idx))
         print(
             "Means of mean evaluations over %d fits (%d evaluations):"
             % (len(df), n_evaluations)

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1063,7 +1063,7 @@ class AgentManager:
 
         return deepcopy(best_trial.params)
 
-    def print_stats(self, B=10_000, alpha=0.05, return_stats=False, n_evaluations=100):
+    def print_stats(self, B=10_000, alpha=0.05, return_stats=False, n_evaluations=50):
         """
         Print some statistics of the data from the last iteration of each fit.
 

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1149,7 +1149,7 @@ class AgentManager:
         ]
 
         print(
-            "Confidence interval of level %.2F for the mean of evaluation over %d fits: "
+            "Confidence interval of level %.2F for the mean of mean evaluation over %d fits: "
             % (1 - alpha, len(df))
         )
         print(

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1149,8 +1149,8 @@ class AgentManager:
         ]
 
         print(
-            "Confidence interval of level %.2F for the mean of %s over %d fits: "
-            % (1 - alpha, tag, len(df))
+            "Confidence interval of level %.2F for the mean of evaluation over %d fits: "
+            % (1 - alpha, len(df))
         )
         print(
             "[%.2F, %.2F]"

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1126,13 +1126,12 @@ class AgentManager:
         print("Mean number of steps per second is %.2F" % (np.mean(spss)))
 
         print("Statistics of the evaluation of fitted agents")
-        eval_values = np.mean(
-            [
-                self.eval_agents(n_evaluations, agent_id=idx, verbose=False)
-                for idx in range(len(df))
-            ],
-            axis=1,
-        )
+        eval_values = []
+        for idx in range(len(df)):
+            eval_values.append(
+                np.mean(self.eval_agents(n_evaluations, agent_id=idx, verbose=False))
+            )
+            logger.info("Evaluating agent " + str(idx))
         print(
             "Means of mean evaluations over %d fits (%d evaluations):"
             % (len(df), n_evaluations)

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1063,7 +1063,7 @@ class AgentManager:
 
         return deepcopy(best_trial.params)
 
-    def print_stats(self, B=10_000, alpha=0.05, return_stats=False, n_evaluations=50):
+    def print_stats(self, B=10_000, alpha=0.05, return_stats=False, n_evaluations=100):
         """
         Print some statistics of the data from the last iteration of each fit.
 
@@ -1078,7 +1078,7 @@ class AgentManager:
         return_stats: bool, default=False
             If True, returns a dictionary with the statistics.
 
-        n_evaluations: int, default=50
+        n_evaluations: int, default=100
             Number of evaluations used.
         """
         datas = self.get_writer_data()

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -50,7 +50,7 @@ def test_agent_manager_1():
     agent.policy(None)
 
     # Run AgentManager
-    params_per_instance = [dict(hyperparameter2=ii) for ii in range(2)]
+    params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
     stats_agent1 = AgentManager(
         DummyAgent,
         train_env,
@@ -73,7 +73,7 @@ def test_agent_manager_1():
     agent_manager_list = [stats_agent1, stats_agent2]
     for st in agent_manager_list:
         st.fit()
-        st.print_stats()
+        st.print_stats(n_evaluations=5, B=10)
 
     for ii, instance in enumerate(stats_agent1.agent_handlers):
         assert instance.hyperparameter1 == -1
@@ -91,7 +91,7 @@ def test_agent_manager_1():
 
     # check if fitted
     for agent_manager in agent_manager_list:
-        assert len(agent_manager.agent_handlers) == 2
+        assert len(agent_manager.agent_handlers) == 4
         for agent in agent_manager.agent_handlers:
             assert agent.fitted
 

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -73,6 +73,7 @@ def test_agent_manager_1():
     agent_manager_list = [stats_agent1, stats_agent2]
     for st in agent_manager_list:
         st.fit()
+        st.print_stats()
 
     for ii, instance in enumerate(stats_agent1.agent_handlers):
         assert instance.hyperparameter1 == -1

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -57,7 +57,7 @@ def test_agent_manager_1():
         fit_budget=5,
         eval_kwargs=eval_kwargs,
         init_kwargs=params,
-        n_fit=2,
+        n_fit=4,
         seed=123,
         init_kwargs_per_instance=params_per_instance,
     )
@@ -67,7 +67,7 @@ def test_agent_manager_1():
         fit_budget=5,
         eval_kwargs=eval_kwargs,
         init_kwargs=params,
-        n_fit=2,
+        n_fit=4,
         seed=123,
     )
     agent_manager_list = [stats_agent1, stats_agent2]


### PR DESCRIPTION
This PR adds a small function to AgentManager that prints some statistics, in particular bootstrap confidence intervals. 
Inspired in part by https://arxiv.org/abs/2108.13264.
Example of script : 
```python

from rlberry.agents.torch import A2CAgent
from rlberry.manager import AgentManager, evaluate_agents
from rlberry.envs import gym_make
import numpy as np
import numpy as np

manager = AgentManager(
    A2CAgent,
    (gym_make, dict(id="CartPole-v1")),
    agent_name="A2CAgent",
    fit_budget=1e4,
    eval_kwargs=dict(eval_horizon=500),
    n_fit=8,
     )
manager.fit()
manager.print_stats()
```


Result of this script:
        
        Statistics of writer data collected on last iteration of each fit.
        Means of values over 8 fits:
        episode_rewards    170.625
        total_episodes     157.625
        dtype: float64
        Medians of values over 8 fits:
        episode_rewards    144.0
        total_episodes     155.0
        dtype: float64
        Confidence interval of level 0.95 for the mean of episode_rewards over 8 fits: 
        [101.25, 249.38]
        Confidence interval of level 0.95 for the mean of total_episodes over 8 fits: 
        [134.38, 180.25]
         
        Mean number of steps per second is 130.97
        Statistics of the evaluation of fitted agents
        
        [INFO] Evaluating agent 0 
        [INFO] Evaluating agent 1 
        [INFO] Evaluating agent 2 
        [INFO] Evaluating agent 3 
        [INFO] Evaluating agent 4 
        [INFO] Evaluating agent 5 
        [INFO] Evaluating agent 6 
        [INFO] Evaluating agent 7 
        
        Means of mean evaluations over 8 fits (100 evaluations):
        episode_rewards    170.625
        total_episodes     157.625
        dtype: float64
        Medians of mean evaluations over 8 fits (100 evaluations):
        Confidence interval of level 0.95 for the mean of mean evaluations over 8 fits: 
        [118.02, 236.24]



Computing these stats can be a bit time-consuming because I need to compute a large number of evaluation (the default is 100) for each of the fitted agent. 

Of particular interest is the last confidence interval, which shows the "efficiency" of the fitted agents on evaluation. Remark that contrary to what is done in `evaluate_agents` there is an aggregation phase (i.e. the 100 evaluations are aggregated using the mean, and the CI is over the 8 fits).

If you have any suggestion, feel free to comment.
@mmcenta on  this.