### PR TITLE
[MRG] eval agent by id 

### DIFF
--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -11,7 +11,6 @@ import gc
 import pickle
 import shutil
 import threading
-import inspect
 import multiprocessing
 from multiprocessing.spawn import _check_not_importing_main
 from typing import List, Optional, Tuple, Union
@@ -22,15 +21,13 @@ import pandas as pd
 import rlberry
 from rlberry.seeding import safe_reseed, set_external_seed
 from rlberry.seeding import Seeder
-from rlberry import metadata_utils, check_packages
+from rlberry import metadata_utils
 from rlberry.envs.utils import process_env
 from rlberry.utils.logging import configure_logging
 from rlberry.utils.writers import DefaultWriter
 from rlberry.manager.utils import create_database
 from rlberry import types
 
-if check_packages.TORCH_INSTALLED:
-    from rlberry.utils.torch import choose_device
 
 _OPTUNA_INSTALLED = True
 try:
@@ -319,23 +316,6 @@ class AgentManager:
 
         # params
         base_init_kwargs = init_kwargs or {}
-
-        if check_packages.TORCH_INSTALLED:
-            # Pre-choose device
-            # Test if 'device' is  one of the parameters of the agent
-            if "device" in inspect.signature(agent_class.__init__).parameters:
-                if "device" in base_init_kwargs.keys():
-                    # If device is in init_kwargs, choose this one
-                    device = base_init_kwargs["device"]
-                else:
-                    # Else, choose the default of the function
-                    device = (
-                        inspect.signature(agent_class.__init__)
-                        .parameters["device"]
-                        .default
-                    )
-                _device = choose_device(device)
-                base_init_kwargs["device"] = _device
 
         self._base_init_kwargs = deepcopy(base_init_kwargs)
         self.fit_kwargs = deepcopy(fit_kwargs)

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 def evaluate_agents(
     agent_manager_list,
     n_simulations=5,
+    choose_random_agents=True,
     fignum=None,
     show=True,
     plot=True,
@@ -29,6 +30,9 @@ def evaluate_agents(
     agent_manager_list : list of AgentManager objects.
     n_simulations: int
         Number of calls to the eval() method of each AgentManager instance.
+    choose_random_agents: bool
+        If true and n_fit>1, use a random fitted agent from each AgentManager at each evaluation.
+        Otherwise, each fitted agent of each AgentManager is evaluated n_simulations times.
     fignum: string or int
         Identifier of plot figure.
     show: bool
@@ -51,7 +55,13 @@ def evaluate_agents(
     eval_outputs = []
     for agent_manager in agent_manager_list:
         logger.info(f"Evaluating {agent_manager.agent_name}...")
-        outputs = agent_manager.eval_agents(n_simulations)
+        if choose_random_agents:
+            outputs = agent_manager.eval_agents(n_simulations)
+        else:
+            outputs = []
+            for idx in range(len(agent_manager.agent_handlers)):
+                outputs += list(agent_manager.eval_agents(n_simulations, agent_id=idx))
+
         if len(outputs) > 0:
             eval_outputs.append(outputs)
 

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -142,9 +142,12 @@ def test_agent_manager_2():
         st.fit()
 
     # compare final policies
-    evaluate_agents(agent_manager_list, show=False)
-    evaluate_agents(agent_manager_list, show=False)
-
+    outputs = evaluate_agents(agent_manager_list, n_simulations=5, show=False)
+    assert len(outputs) == 5
+    outputs = evaluate_agents(
+        agent_manager_list, n_simulations=5, show=False, choose_random_agents=False
+    )
+    assert len(outputs) == 4 * 5
     # learning curves
     plot_writer_data(agent_manager_list, tag="episode_rewards", show=False)
 


### PR DESCRIPTION
In this PR I change small things in AgentManager

- Now the device is pre-chosen. The goal is to avoid the choice of device at each call of the agent.
- I add the possibility to specify the agent that one evaluate in AgentManager and I add a verbose parameter to silence just the eval messages.

As a result of this PR, I avoid the repeated messages mentionned in issue #211. 

For now, I chose to keep the gym.make messages mentionned in #211 because I don't see an easy way to keep only one and I don't want to remove them altogether.