### PR TITLE
feat (logging) Improve logging

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -176,6 +176,15 @@ Check Utilities
    utils.check_seeding_agent
    utils.check_agent_manager
 
+Logging Utilities
+-----------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+
+   utils.logging.set_level
+
 
 Typing
 ------

--- a/examples/demo_bandits/plot_mirror_bandit.py
+++ b/examples/demo_bandits/plot_mirror_bandit.py
@@ -24,7 +24,9 @@ import requests
 import matplotlib.pyplot as plt
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 # Environment definition
 

--- a/examples/demo_bandits/plot_mirror_bandit.py
+++ b/examples/demo_bandits/plot_mirror_bandit.py
@@ -19,7 +19,7 @@ from rlberry.envs.interface import Model
 from rlberry.agents.bandits import BanditWithSimplePolicy
 from rlberry.wrappers import WriterWrapper
 import rlberry.spaces as spaces
-import logging
+
 import requests
 import matplotlib.pyplot as plt
 

--- a/rlberry/__init__.py
+++ b/rlberry/__init__.py
@@ -1,13 +1,17 @@
 from ._version import __version__
+import logging
+
+logger = logging.getLogger("rlberry_logger")
+
 from rlberry.utils.logging import configure_logging
 
 
 __path__ = __import__("pkgutil").extend_path(__path__, __name__)
 
 # Initialize logging level
-
 configure_logging(level="INFO")
+
 
 # define __version__
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "logger"]

--- a/rlberry/agents/adaptiveql/adaptiveql.py
+++ b/rlberry/agents/adaptiveql/adaptiveql.py
@@ -4,7 +4,9 @@ import numpy as np
 from rlberry.agents import AgentWithSimplePolicy
 from rlberry.agents.adaptiveql.tree import MDPTreePartition
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class AdaptiveQLAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/adaptiveql/adaptiveql.py
+++ b/rlberry/agents/adaptiveql/adaptiveql.py
@@ -1,4 +1,3 @@
-import logging
 import gym.spaces as spaces
 import numpy as np
 from rlberry.agents import AgentWithSimplePolicy

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -1,7 +1,6 @@
 from abc import ABC, abstractmethod
 import dill
 import pickle
-import logging
 import numpy as np
 from inspect import signature
 from pathlib import Path

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -14,8 +14,9 @@ from rlberry.utils.writers import DefaultWriter
 from typing import Optional
 import inspect
 
+import rlberry
 
-logger = logging.getLogger(__name__)
+logger = rlberry.logger
 
 
 class Agent(ABC):

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -5,7 +5,9 @@ import pickle
 import logging
 from pathlib import Path
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class BanditWithSimplePolicy(AgentWithSimplePolicy):

--- a/rlberry/agents/bandits/bandit_base.py
+++ b/rlberry/agents/bandits/bandit_base.py
@@ -2,7 +2,7 @@ import numpy as np
 from rlberry.agents import AgentWithSimplePolicy
 from .tools import BanditTracker
 import pickle
-import logging
+
 from pathlib import Path
 
 import rlberry

--- a/rlberry/agents/bandits/index_agents.py
+++ b/rlberry/agents/bandits/index_agents.py
@@ -2,7 +2,9 @@ import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 # TODO : fix bug when doing several fit, the fit do not resume. Should define
 #        self.rewards and self.action and resume training.

--- a/rlberry/agents/bandits/index_agents.py
+++ b/rlberry/agents/bandits/index_agents.py
@@ -1,6 +1,6 @@
 import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
-import logging
+
 
 import rlberry
 

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -2,7 +2,9 @@ import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class RandomizedAgent(BanditWithSimplePolicy):

--- a/rlberry/agents/bandits/randomized_agents.py
+++ b/rlberry/agents/bandits/randomized_agents.py
@@ -1,6 +1,6 @@
 import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
-import logging
+
 
 import rlberry
 

--- a/rlberry/agents/bandits/tools/tracker.py
+++ b/rlberry/agents/bandits/tools/tracker.py
@@ -2,7 +2,9 @@ import logging
 from rlberry import metadata_utils
 from rlberry.utils.writers import DefaultWriter
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class BanditTracker(DefaultWriter):

--- a/rlberry/agents/bandits/tools/tracker.py
+++ b/rlberry/agents/bandits/tools/tracker.py
@@ -1,4 +1,3 @@
-import logging
 from rlberry import metadata_utils
 from rlberry.utils.writers import DefaultWriter
 

--- a/rlberry/agents/bandits/ts_agents.py
+++ b/rlberry/agents/bandits/ts_agents.py
@@ -1,6 +1,6 @@
 import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
-import logging
+
 
 import rlberry
 

--- a/rlberry/agents/bandits/ts_agents.py
+++ b/rlberry/agents/bandits/ts_agents.py
@@ -2,7 +2,9 @@ import numpy as np
 from rlberry.agents.bandits import BanditWithSimplePolicy
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class TSAgent(BanditWithSimplePolicy):

--- a/rlberry/agents/experimental/jax/dqn/dqn.py
+++ b/rlberry/agents/experimental/jax/dqn/dqn.py
@@ -43,7 +43,9 @@ from rlberry.agents import AgentWithSimplePolicy
 from rlberry.agents.jax.utils.replay_buffer import ReplayBuffer
 from typing import Any, Callable, Mapping, Optional
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 @chex.dataclass

--- a/rlberry/agents/experimental/jax/dqn/dqn.py
+++ b/rlberry/agents/experimental/jax/dqn/dqn.py
@@ -29,7 +29,7 @@ import functools
 import haiku as hk
 import jax
 import jax.numpy as jnp
-import logging
+
 import numpy as np
 import optax
 import dill

--- a/rlberry/agents/experimental/jax/utils/replay_buffer.py
+++ b/rlberry/agents/experimental/jax/utils/replay_buffer.py
@@ -8,7 +8,9 @@ Notes
 import logging
 import tensorflow as tf
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 try:
     import reverb

--- a/rlberry/agents/experimental/jax/utils/replay_buffer.py
+++ b/rlberry/agents/experimental/jax/utils/replay_buffer.py
@@ -5,7 +5,7 @@ Notes
 * For priority updates, see https://github.com/deepmind/reverb/issues/28
 """
 
-import logging
+
 import tensorflow as tf
 
 import rlberry

--- a/rlberry/agents/experimental/torch/avec/avec_ppo.py
+++ b/rlberry/agents/experimental/torch/avec/avec_ppo.py
@@ -1,5 +1,5 @@
 import torch
-import logging
+
 import torch.nn as nn
 import inspect
 

--- a/rlberry/agents/experimental/torch/avec/avec_ppo.py
+++ b/rlberry/agents/experimental/torch/avec/avec_ppo.py
@@ -12,7 +12,9 @@ from rlberry.agents.torch.utils.models import default_value_net_fn
 from rlberry.utils.torch import choose_device
 from rlberry.wrappers.uncertainty_estimator_wrapper import UncertaintyEstimatorWrapper
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class AVECPPOAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/experimental/torch/sac/sac.py
+++ b/rlberry/agents/experimental/torch/sac/sac.py
@@ -3,7 +3,7 @@ from .utils import ReplayBuffer, get_qref, get_vref, alpha_sync
 import torch
 import torch.nn as nn
 from torch.nn.functional import one_hot
-import logging
+
 import gym.spaces as spaces
 
 from rlberry.agents import AgentWithSimplePolicy

--- a/rlberry/agents/experimental/torch/sac/sac.py
+++ b/rlberry/agents/experimental/torch/sac/sac.py
@@ -14,7 +14,9 @@ from rlberry.agents.torch.utils.models import default_twinq_net_fn
 from rlberry.utils.torch import choose_device
 from rlberry.wrappers.uncertainty_estimator_wrapper import UncertaintyEstimatorWrapper
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class SACAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
@@ -11,7 +11,9 @@ from rlberry.utils.metrics import metric_lp
 from rlberry.agents.kernel_based.kernels import kernel_func
 from rlberry.agents.kernel_based.common import map_to_representative
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 @numba_jit

--- a/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_kernel_ucbvi.py
@@ -1,5 +1,3 @@
-import logging
-
 import numpy as np
 from rlberry.utils.jit_setup import numba_jit
 

--- a/rlberry/agents/kernel_based/rs_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_ucbvi.py
@@ -1,4 +1,3 @@
-import logging
 from rlberry.agents.agent import AgentWithSimplePolicy
 import numpy as np
 

--- a/rlberry/agents/kernel_based/rs_ucbvi.py
+++ b/rlberry/agents/kernel_based/rs_ucbvi.py
@@ -7,7 +7,9 @@ from rlberry.agents.dynprog.utils import backward_induction
 from rlberry.agents.dynprog.utils import backward_induction_in_place
 from rlberry.agents.kernel_based.common import map_to_representative
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class RSUCBVIAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/linear/lsvi_ucb.py
+++ b/rlberry/agents/linear/lsvi_ucb.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 from rlberry.agents import AgentWithSimplePolicy
 from gym.spaces import Discrete

--- a/rlberry/agents/linear/lsvi_ucb.py
+++ b/rlberry/agents/linear/lsvi_ucb.py
@@ -4,7 +4,9 @@ from rlberry.agents import AgentWithSimplePolicy
 from gym.spaces import Discrete
 from rlberry.utils.jit_setup import numba_jit
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 @numba_jit

--- a/rlberry/agents/mbqvi/mbqvi.py
+++ b/rlberry/agents/mbqvi/mbqvi.py
@@ -1,5 +1,5 @@
 import numpy as np
-import logging
+
 
 from rlberry.agents import AgentWithSimplePolicy
 from rlberry.agents.dynprog.utils import backward_induction, value_iteration

--- a/rlberry/agents/mbqvi/mbqvi.py
+++ b/rlberry/agents/mbqvi/mbqvi.py
@@ -5,7 +5,9 @@ from rlberry.agents import AgentWithSimplePolicy
 from rlberry.agents.dynprog.utils import backward_induction, value_iteration
 from gym.spaces import Discrete
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class MBQVIAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/optql/optql.py
+++ b/rlberry/agents/optql/optql.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 
 import gym.spaces as spaces

--- a/rlberry/agents/optql/optql.py
+++ b/rlberry/agents/optql/optql.py
@@ -5,7 +5,9 @@ import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy
 from rlberry.exploration_tools.discrete_counter import DiscreteCounter
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class OptQLAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/psrl/psrl.py
+++ b/rlberry/agents/psrl/psrl.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 
 import gym.spaces as spaces

--- a/rlberry/agents/psrl/psrl.py
+++ b/rlberry/agents/psrl/psrl.py
@@ -9,7 +9,9 @@ from rlberry.agents.dynprog.utils import (
     backward_induction_sd,
 )
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class PSRLAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/rlsvi/rlsvi.py
+++ b/rlberry/agents/rlsvi/rlsvi.py
@@ -10,7 +10,9 @@ from rlberry.agents.dynprog.utils import (
     backward_induction_sd,
 )
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class RLSVIAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/rlsvi/rlsvi.py
+++ b/rlberry/agents/rlsvi/rlsvi.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 
 import gym.spaces as spaces

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -1,4 +1,3 @@
-import logging
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple, Type, Union
 

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -13,7 +13,9 @@ from rlberry import types
 from rlberry.agents import AgentWithSimplePolicy
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def is_recordable(value: Any) -> bool:

--- a/rlberry/agents/torch/a2c/a2c.py
+++ b/rlberry/agents/torch/a2c/a2c.py
@@ -13,7 +13,9 @@ from rlberry.utils.torch import choose_device
 from rlberry.utils.factory import load
 from typing import Optional
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class A2CAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/torch/a2c/a2c.py
+++ b/rlberry/agents/torch/a2c/a2c.py
@@ -1,6 +1,5 @@
 import torch
 import torch.nn as nn
-import logging
 
 import gym.spaces as spaces
 import numpy as np

--- a/rlberry/agents/torch/dqn/dqn.py
+++ b/rlberry/agents/torch/dqn/dqn.py
@@ -1,4 +1,3 @@
-import logging
 import inspect
 
 import numpy as np

--- a/rlberry/agents/torch/dqn/dqn.py
+++ b/rlberry/agents/torch/dqn/dqn.py
@@ -19,7 +19,9 @@ from rlberry.utils.factory import load
 from typing import Callable, Optional, Union
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def default_q_net_fn(env, **kwargs):

--- a/rlberry/agents/torch/dqn/dqn_utils.py
+++ b/rlberry/agents/torch/dqn/dqn_utils.py
@@ -3,7 +3,9 @@ import logging
 from rlberry.utils.jit_setup import numba_jit
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def polynomial_schedule(
@@ -15,39 +17,39 @@ def polynomial_schedule(
 ):
     """Constructs a schedule with polynomial transition from init to end value.
 
-    Notes
-    -----
-    Function taken from: https://github.com/deepmind/optax/blob/master/optax/_src/schedule.py,
-    which is licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+        Notes
+        -----
+        Function taken from: https://github.com/deepmind/optax/blob/master/optax/_src/schedule.py,
+        which is licensed under the Apache License, Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
 
-    Modifications with respect to source:
+        Modifications with respect to source:
 
-    * Remove chex typing from the arguments.
-    * Log using a logger :code:`logging.getLogger(__name__)` instead of :code:`logging.info()`.
-    * Changed documentation style.
+        * Remove chex typing from the arguments.
+    import rlberry; logger=rlberry.logger` instead of :code:`logging.info()`.
+        * Changed documentation style.
 
-    Parameters
-    ----------
-    init_value: float
-        Initial value for the scalar to be annealed.
-    end_value: float
-        End value of the scalar to be annealed.
-    power: float
-        The power of the polynomial used to transition from init to end.
-    transition_steps: float
-        Number of steps over which annealing takes place,
-        the scalar starts changing at `transition_begin` steps and completes
-        the transition by `transition_begin + transition_steps` steps.
-        If `transition_steps <= 0`, then the entire annealing process is disabled
-        and the value is held fixed at `init_value`.
-    transition_begin: float
-        Must be positive. After how many steps to start annealing
-        (before this many steps the scalar value is held fixed at `init_value`).
+        Parameters
+        ----------
+        init_value: float
+            Initial value for the scalar to be annealed.
+        end_value: float
+            End value of the scalar to be annealed.
+        power: float
+            The power of the polynomial used to transition from init to end.
+        transition_steps: float
+            Number of steps over which annealing takes place,
+            the scalar starts changing at `transition_begin` steps and completes
+            the transition by `transition_begin + transition_steps` steps.
+            If `transition_steps <= 0`, then the entire annealing process is disabled
+            and the value is held fixed at `init_value`.
+        transition_begin: float
+            Must be positive. After how many steps to start annealing
+            (before this many steps the scalar value is held fixed at `init_value`).
 
-    Returns
-    -------
-    schedule: Callable[[int], float]
-        A function that maps step counts to values.
+        Returns
+        -------
+        schedule: Callable[[int], float]
+            A function that maps step counts to values.
     """
     if transition_steps <= 0:
         logger.info(

--- a/rlberry/agents/torch/dqn/dqn_utils.py
+++ b/rlberry/agents/torch/dqn/dqn_utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-import logging
+
 from rlberry.utils.jit_setup import numba_jit
 
 

--- a/rlberry/agents/torch/ppo/ppo.py
+++ b/rlberry/agents/torch/ppo/ppo.py
@@ -18,7 +18,9 @@ from rlberry.utils.factory import load
 # from rlberry.envs import gym_make
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class PPOAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/torch/ppo/ppo.py
+++ b/rlberry/agents/torch/ppo/ppo.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
 import torch.nn as nn
-import logging
+
 
 import gym.spaces as spaces
 from rlberry.agents import AgentWithSimplePolicy

--- a/rlberry/agents/torch/reinforce/reinforce.py
+++ b/rlberry/agents/torch/reinforce/reinforce.py
@@ -9,7 +9,9 @@ from rlberry.agents.torch.utils.training import optimizer_factory
 from rlberry.agents.torch.utils.models import default_policy_net_fn
 from rlberry.utils.torch import choose_device
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class REINFORCEAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/torch/reinforce/reinforce.py
+++ b/rlberry/agents/torch/reinforce/reinforce.py
@@ -1,4 +1,3 @@
-import logging
 import torch
 import inspect
 

--- a/rlberry/agents/ucbvi/ucbvi.py
+++ b/rlberry/agents/ucbvi/ucbvi.py
@@ -14,7 +14,9 @@ from rlberry.agents.dynprog.utils import (
 )
 from rlberry.agents.dynprog.utils import backward_induction_in_place
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class UCBVIAgent(AgentWithSimplePolicy):

--- a/rlberry/agents/ucbvi/ucbvi.py
+++ b/rlberry/agents/ucbvi/ucbvi.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 
 import gym.spaces as spaces

--- a/rlberry/agents/utils/replay.py
+++ b/rlberry/agents/utils/replay.py
@@ -8,7 +8,9 @@ from typing import NamedTuple
 from rlberry.agents.utils import replay_utils
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class Batch(NamedTuple):

--- a/rlberry/agents/utils/replay.py
+++ b/rlberry/agents/utils/replay.py
@@ -3,7 +3,7 @@ New module aiming to replace memories.py
 """
 
 import numpy as np
-import logging
+
 from typing import NamedTuple
 from rlberry.agents.utils import replay_utils
 

--- a/rlberry/envs/bandits/bandit_base.py
+++ b/rlberry/envs/bandits/bandit_base.py
@@ -5,7 +5,9 @@ from rlberry.envs.interface import Model
 import rlberry.spaces as spaces
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class Bandit(Model):

--- a/rlberry/envs/bandits/bandit_base.py
+++ b/rlberry/envs/bandits/bandit_base.py
@@ -1,5 +1,5 @@
 from collections import deque
-import logging
+
 
 from rlberry.envs.interface import Model
 import rlberry.spaces as spaces

--- a/rlberry/envs/benchmarks/ball_exploration/pball.py
+++ b/rlberry/envs/benchmarks/ball_exploration/pball.py
@@ -1,5 +1,5 @@
 import numpy as np
-import logging
+
 
 import rlberry.spaces as spaces
 from rlberry.envs.interface import Model

--- a/rlberry/envs/benchmarks/ball_exploration/pball.py
+++ b/rlberry/envs/benchmarks/ball_exploration/pball.py
@@ -5,7 +5,9 @@ import rlberry.spaces as spaces
 from rlberry.envs.interface import Model
 from rlberry.rendering import Scene, GeometricPrimitive, RenderInterface2D
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def projection_to_pball(x, p):

--- a/rlberry/envs/benchmarks/generalization/twinrooms.py
+++ b/rlberry/envs/benchmarks/generalization/twinrooms.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import rlberry.spaces as spaces
 from rlberry.envs import Model

--- a/rlberry/envs/benchmarks/generalization/twinrooms.py
+++ b/rlberry/envs/benchmarks/generalization/twinrooms.py
@@ -5,7 +5,9 @@ from rlberry.envs import Model
 from rlberry.rendering import Scene, GeometricPrimitive, RenderInterface2D
 from rlberry.rendering.common_shapes import circle_shape
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class TwinRooms(RenderInterface2D, Model):

--- a/rlberry/envs/benchmarks/grid_exploration/apple_gold.py
+++ b/rlberry/envs/benchmarks/grid_exploration/apple_gold.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld

--- a/rlberry/envs/benchmarks/grid_exploration/apple_gold.py
+++ b/rlberry/envs/benchmarks/grid_exploration/apple_gold.py
@@ -4,7 +4,9 @@ import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld
 from rlberry.rendering import Scene, GeometricPrimitive
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class AppleGold(GridWorld):

--- a/rlberry/envs/benchmarks/grid_exploration/four_room.py
+++ b/rlberry/envs/benchmarks/grid_exploration/four_room.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld

--- a/rlberry/envs/benchmarks/grid_exploration/four_room.py
+++ b/rlberry/envs/benchmarks/grid_exploration/four_room.py
@@ -3,7 +3,9 @@ import numpy as np
 import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class FourRoom(GridWorld):

--- a/rlberry/envs/benchmarks/grid_exploration/nroom.py
+++ b/rlberry/envs/benchmarks/grid_exploration/nroom.py
@@ -5,7 +5,9 @@ import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld
 from rlberry.rendering import Scene, GeometricPrimitive
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def get_nroom_state_coord(state_index, nroom_env):

--- a/rlberry/envs/benchmarks/grid_exploration/nroom.py
+++ b/rlberry/envs/benchmarks/grid_exploration/nroom.py
@@ -1,4 +1,3 @@
-import logging
 import math
 import numpy as np
 import rlberry.spaces as spaces

--- a/rlberry/envs/benchmarks/grid_exploration/six_room.py
+++ b/rlberry/envs/benchmarks/grid_exploration/six_room.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld

--- a/rlberry/envs/benchmarks/grid_exploration/six_room.py
+++ b/rlberry/envs/benchmarks/grid_exploration/six_room.py
@@ -4,7 +4,9 @@ import rlberry.spaces as spaces
 from rlberry.envs.finite import GridWorld
 from rlberry.rendering import Scene, GeometricPrimitive
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class SixRoom(GridWorld):

--- a/rlberry/envs/finite/finite_mdp.py
+++ b/rlberry/envs/finite/finite_mdp.py
@@ -1,5 +1,5 @@
 import numpy as np
-import logging
+
 
 import rlberry.spaces as spaces
 from rlberry.envs.interface import Model

--- a/rlberry/envs/finite/finite_mdp.py
+++ b/rlberry/envs/finite/finite_mdp.py
@@ -4,7 +4,9 @@ import logging
 import rlberry.spaces as spaces
 from rlberry.envs.interface import Model
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class FiniteMDP(Model):

--- a/rlberry/envs/finite/gridworld.py
+++ b/rlberry/envs/finite/gridworld.py
@@ -1,6 +1,6 @@
 import matplotlib
 import numpy as np
-import logging
+
 import matplotlib.pyplot as plt
 from matplotlib import cm
 

--- a/rlberry/envs/finite/gridworld.py
+++ b/rlberry/envs/finite/gridworld.py
@@ -10,7 +10,9 @@ from rlberry.rendering import Scene, GeometricPrimitive, RenderInterface2D
 from rlberry.rendering.common_shapes import circle_shape
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class GridWorld(RenderInterface2D, FiniteMDP):

--- a/rlberry/envs/interface/model.py
+++ b/rlberry/envs/interface/model.py
@@ -1,6 +1,6 @@
 import gym
 import numpy as np
-import logging
+
 import inspect
 from rlberry.seeding import Seeder
 

--- a/rlberry/envs/interface/model.py
+++ b/rlberry/envs/interface/model.py
@@ -4,7 +4,9 @@ import logging
 import inspect
 from rlberry.seeding import Seeder
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class Model(gym.Env):

--- a/rlberry/envs/utils.py
+++ b/rlberry/envs/utils.py
@@ -1,7 +1,7 @@
 from typing import Tuple
 from copy import deepcopy
 from rlberry.seeding import safe_reseed
-import logging
+
 
 import rlberry
 

--- a/rlberry/envs/utils.py
+++ b/rlberry/envs/utils.py
@@ -3,7 +3,9 @@ from copy import deepcopy
 from rlberry.seeding import safe_reseed
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def process_env(env, seeder, copy_env=True):

--- a/rlberry/experiment/generator.py
+++ b/rlberry/experiment/generator.py
@@ -19,7 +19,9 @@ from rlberry.experiment.yaml_utils import parse_experiment_config
 from rlberry.manager import AgentManager
 from rlberry import check_packages
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def experiment_generator():

--- a/rlberry/experiment/generator.py
+++ b/rlberry/experiment/generator.py
@@ -12,7 +12,7 @@ Options:
     --parallelization=<par>  Either 'thread' or 'process' [default: process].
     --max_workers=<workers>  Number of workers used by AgentManager.fit. Set to -1 for the maximum value. [default: -1]
 """
-import logging
+
 from docopt import docopt
 from pathlib import Path
 from rlberry.experiment.yaml_utils import parse_experiment_config

--- a/rlberry/experiment/load_results.py
+++ b/rlberry/experiment/load_results.py
@@ -3,7 +3,9 @@ from rlberry.manager import AgentManager
 import pandas as pd
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def _get_most_recent_path(path_list):

--- a/rlberry/experiment/load_results.py
+++ b/rlberry/experiment/load_results.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from rlberry.manager import AgentManager
 import pandas as pd
-import logging
+
 
 import rlberry
 

--- a/rlberry/exploration_tools/online_discretization_counter.py
+++ b/rlberry/exploration_tools/online_discretization_counter.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 from rlberry.utils.jit_setup import numba_jit
 from rlberry.exploration_tools.uncertainty_estimator import UncertaintyEstimator

--- a/rlberry/exploration_tools/online_discretization_counter.py
+++ b/rlberry/exploration_tools/online_discretization_counter.py
@@ -6,7 +6,9 @@ from rlberry.exploration_tools.typing import preprocess_args
 from gym.spaces import Box, Discrete
 from rlberry.utils.metrics import metric_lp
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 @numba_jit

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -523,6 +523,15 @@ class AgentManager:
         if not n_simulations:
             n_simulations = 2 * self.n_fit
         values = []
+
+        if logger.getEffectiveLevel() > 10:
+            previous_handlers = logger.handlers
+            ch = logging.StreamHandler()
+            ch.terminator = ""
+            formatter = logging.Formatter("%(message)s")
+            ch.setFormatter(formatter)
+            logger.handlers = [ch]
+            logger.info("[INFO] Evaluation:")
         for ii in range(n_simulations):
             if agent_id is None:
                 # randomly choose one of the fitted agents
@@ -537,8 +546,14 @@ class AgentManager:
                 )
                 return []
             values.append(agent.eval(**eval_kwargs))
-            if verbose:
-                logger.info(f"[eval]... simulation {ii + 1}/{n_simulations}")
+            if logger.getEffectiveLevel() <= 10:  # If debug
+                logger.debug(f"[eval]... simulation {ii + 1}/{n_simulations}")
+            else:
+                logger.info(".")
+        if logger.getEffectiveLevel() > 10:
+            logger.info("  Evaluation finished \n")
+            logger.handlers = previous_handlers
+
         return values
 
     def clear_output_dir(self):

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -496,7 +496,6 @@ class AgentManager:
         n_simulations: Optional[int] = None,
         eval_kwargs: Optional[dict] = None,
         agent_id: Optional[int] = None,
-        verbose: Optional[bool] = True,
     ) -> List[float]:
         """
         Call :meth:`eval` method in the managed agents and returns a list with the results.
@@ -510,8 +509,6 @@ class AgentManager:
             If None, set to self.eval_kwargs.
         agent_id: int, optional
             Index of the agent to be evaluated. If None, choose randomly.
-        verbose: bool, optional
-            Whether to print a progress report.
 
         Returns
         -------

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -532,6 +532,7 @@ class AgentManager:
             ch.setFormatter(formatter)
             logger.handlers = [ch]
             logger.info("[INFO] Evaluation:")
+
         for ii in range(n_simulations):
             if agent_id is None:
                 # randomly choose one of the fitted agents

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -35,10 +35,8 @@ try:
 except Exception:
     _OPTUNA_INSTALLED = False
 
-logger = logging.getLogger(__name__)
+logger = rlberry.logger
 
-
-#
 # Aux
 #
 
@@ -203,8 +201,9 @@ class AgentManager:
         Warning: If you're using JAX or PyTorch, it only works with 'spawn'.
                  If running code on a notebook or interpreter, use 'fork'.
                  forkserver and fork are available on Unix OS only.
-        worker_logging_level : str, default: 'INFO'
-        Logging level in each of the threads/processes used to fit agents.
+        worker_logging_level : str, default: None
+            Logging level in each of the threads/processes used to fit agents.
+            If None, use default logger level.
     seed : :class:`numpy.random.SeedSequence`, :class:`~rlberry.seeding.seeder.Seeder` or int, default : None
         Seed sequence from which to spawn the random number generator.
         If None, generate random seed.
@@ -251,7 +250,7 @@ class AgentManager:
         parallelization="thread",
         max_workers=None,
         mp_context="spawn",
-        worker_logging_level="INFO",
+        worker_logging_level=None,
         seed=None,
         enable_tensorboard=False,
         outdir_id_style="timestamp",
@@ -324,7 +323,9 @@ class AgentManager:
         self.parallelization = parallelization
         self.max_workers = max_workers
         self.mp_context = mp_context
-        self.worker_logging_level = worker_logging_level
+        self.worker_logging_level = worker_logging_level or logging.getLevelName(
+            logger.getEffectiveLevel()
+        )
         self.output_dir = output_dir
         if fit_budget is not None:
             self.fit_budget = fit_budget

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -496,6 +496,7 @@ class AgentManager:
         n_simulations: Optional[int] = None,
         eval_kwargs: Optional[dict] = None,
         agent_id: Optional[int] = None,
+        verbose: Optional[bool] = True,
     ) -> List[float]:
         """
         Call :meth:`eval` method in the managed agents and returns a list with the results.
@@ -509,6 +510,8 @@ class AgentManager:
             If None, set to self.eval_kwargs.
         agent_id: int, optional
             Index of the agent to be evaluated. If None, choose randomly.
+        verbose: bool, optional
+            Whether to print a progress report.
 
         Returns
         -------
@@ -521,14 +524,15 @@ class AgentManager:
             n_simulations = 2 * self.n_fit
         values = []
 
-        if logger.getEffectiveLevel() > 10:
-            previous_handlers = logger.handlers
-            ch = logging.StreamHandler()
-            ch.terminator = ""
-            formatter = logging.Formatter("%(message)s")
-            ch.setFormatter(formatter)
-            logger.handlers = [ch]
-            logger.info("[INFO] Evaluation:")
+        if verbose:
+            if logger.getEffectiveLevel() > 10:
+                previous_handlers = logger.handlers
+                ch = logging.StreamHandler()
+                ch.terminator = ""
+                formatter = logging.Formatter("%(message)s")
+                ch.setFormatter(formatter)
+                logger.handlers = [ch]
+                logger.info("[INFO] Evaluation:")
 
         for ii in range(n_simulations):
             if agent_id is None:
@@ -544,13 +548,15 @@ class AgentManager:
                 )
                 return []
             values.append(agent.eval(**eval_kwargs))
-            if logger.getEffectiveLevel() <= 10:  # If debug
-                logger.debug(f"[eval]... simulation {ii + 1}/{n_simulations}")
-            else:
-                logger.info(".")
-        if logger.getEffectiveLevel() > 10:
-            logger.info("  Evaluation finished \n")
-            logger.handlers = previous_handlers
+            if verbose:
+                if logger.getEffectiveLevel() <= 10:  # If debug
+                    logger.debug(f"[eval]... simulation {ii + 1}/{n_simulations}")
+                else:
+                    logger.info(".")
+        if verbose:
+            if logger.getEffectiveLevel() > 10:
+                logger.info("  Evaluation finished \n")
+                logger.handlers = previous_handlers
 
         return values
 

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -10,7 +10,9 @@ from itertools import cycle
 from rlberry.manager import AgentManager
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def evaluate_agents(

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -1,4 +1,3 @@
-import logging
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd

--- a/rlberry/manager/remote_agent_manager.py
+++ b/rlberry/manager/remote_agent_manager.py
@@ -11,7 +11,9 @@ from rlberry.network import interface
 from rlberry.network.client import BerryClient
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class RemoteAgentManager:

--- a/rlberry/manager/remote_agent_manager.py
+++ b/rlberry/manager/remote_agent_manager.py
@@ -1,7 +1,7 @@
 import base64
 import dill
 import io
-import logging
+
 import pandas as pd
 import pathlib
 import pickle

--- a/rlberry/network/server.py
+++ b/rlberry/network/server.py
@@ -14,7 +14,9 @@ from rlberry.envs import gym_make
 from typing import Optional
 
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class ClientHandler:

--- a/rlberry/rendering/opengl_render2d.py
+++ b/rlberry/rendering/opengl_render2d.py
@@ -7,7 +7,9 @@ from os import environ
 import logging
 from rlberry.rendering import Scene
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 
 _IMPORT_SUCESSFUL = True

--- a/rlberry/rendering/opengl_render2d.py
+++ b/rlberry/rendering/opengl_render2d.py
@@ -4,7 +4,7 @@ OpenGL code for 2D rendering, using pygame.
 
 import numpy as np
 from os import environ
-import logging
+
 from rlberry.rendering import Scene
 
 import rlberry

--- a/rlberry/rendering/pygame_render2d.py
+++ b/rlberry/rendering/pygame_render2d.py
@@ -4,7 +4,7 @@ Code for 2D rendering, using pygame (without OpenGL)
 
 import numpy as np
 from os import environ
-import logging
+
 from rlberry.rendering import Scene
 
 import rlberry

--- a/rlberry/rendering/pygame_render2d.py
+++ b/rlberry/rendering/pygame_render2d.py
@@ -7,7 +7,9 @@ from os import environ
 import logging
 from rlberry.rendering import Scene
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 environ["PYGAME_HIDE_SUPPORT_PROMPT"] = "1"
 

--- a/rlberry/rendering/render_interface.py
+++ b/rlberry/rendering/render_interface.py
@@ -9,7 +9,9 @@ from rlberry.rendering.opengl_render2d import OpenGLRender2D
 from rlberry.rendering.pygame_render2d import PyGameRender2D
 from rlberry.rendering.utils import video_write
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class RenderInterface(ABC):

--- a/rlberry/rendering/render_interface.py
+++ b/rlberry/rendering/render_interface.py
@@ -2,7 +2,7 @@
 Interface that allows 2D rendering.
 """
 
-import logging
+
 from abc import ABC, abstractmethod
 
 from rlberry.rendering.opengl_render2d import OpenGLRender2D

--- a/rlberry/rendering/utils.py
+++ b/rlberry/rendering/utils.py
@@ -1,5 +1,5 @@
 import numpy as np
-import logging
+
 
 _FFMPEG_INSTALLED = True
 try:

--- a/rlberry/rendering/utils.py
+++ b/rlberry/rendering/utils.py
@@ -7,7 +7,9 @@ try:
 except Exception:
     _FFMPEG_INSTALLED = False
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def video_write(fn, images, framerate=60, vcodec="libx264"):

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -69,6 +69,7 @@ def configure_logging(
         Message to append to the beginning all logs (e.g. thread id).
     """
     standard_msg_fmt = default_msg + "[%(levelname)s] %(asctime)s: %(message)s "
+    # WARNING : if this standard message is changed, then the multi_line writer log style will bugg.
     config = {
         "version": 1,
         "disable_existing_loggers": False,

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -8,6 +8,8 @@ import rlberry
 def set_level(level="INFO"):
     rlberry.logger.setLevel(level)
     gym.logger.set_level(logging.getLevelName(level))
+    for ch in rlberry.logger.handlers:
+        ch.setLevel(level)
 
 
 def configure_logging(

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -1,6 +1,13 @@
+import logging
 import logging.config
 from pathlib import Path
 import gym
+import rlberry
+
+
+def set_level(level="INFO"):
+    rlberry.logger.setLevel(level)
+    gym.logger.set_level(logging.getLevelName(level))
 
 
 def configure_logging(
@@ -42,7 +49,13 @@ def configure_logging(
                 "class": "logging.StreamHandler",
             }
         },
-        "loggers": {"": {"handlers": ["default"], "level": "DEBUG", "propagate": True}},
+        "loggers": {
+            "rlberry_logger": {
+                "handlers": ["default"],
+                "level": level,
+                "propagate": True,
+            }
+        },
     }
     if file_path:
         config["handlers"][file_path.name] = {

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -67,6 +67,8 @@ def configure_logging(
         }
         config["loggers"][""]["handlers"].append(file_path.name)
     logging.config.dictConfig(config)
-    gym.logger.set_level(logging.getLevelName(level))
+    gym.logger.set_level(
+        logging.getLevelName(level) + 10
+    )  # If info -> go to warning gym level. If debug, go to info.
     numba_logger = logging.getLogger("numba")
     numba_logger.setLevel(logging.WARNING)

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -44,7 +44,7 @@ class ColoredFormatter(logging.Formatter):
 
     def format(self, record):
         log_fmt = self.FORMATS.get(record.levelno)
-        formatter = logging.Formatter(log_fmt, datefmt="%H:%M:%S")
+        formatter = logging.Formatter(log_fmt, datefmt="%H:%M")
         return formatter.format(record)
 
 
@@ -68,7 +68,7 @@ def configure_logging(
     default_msg
         Message to append to the beginning all logs (e.g. thread id).
     """
-    standard_msg_fmt = default_msg + "[%(levelname)s] %(asctime)s : %(message)s "
+    standard_msg_fmt = default_msg + "[%(levelname)s] %(asctime)s: %(message)s "
     config = {
         "version": 1,
         "disable_existing_loggers": False,

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -6,6 +6,14 @@ import rlberry
 
 
 def set_level(level="INFO"):
+    """
+    Set rlberry's logger level.
+
+    Parameters
+    ----------
+    level: str in {'NOTSET', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'}
+        Level of the logger.
+    """
     rlberry.logger.setLevel(level)
     gym.logger.set_level(logging.getLevelName(level))
     for ch in rlberry.logger.handlers:

--- a/rlberry/utils/logging.py
+++ b/rlberry/utils/logging.py
@@ -15,7 +15,7 @@ def set_level(level="INFO"):
         Level of the logger.
     """
     rlberry.logger.setLevel(level)
-    gym.logger.set_level(logging.getLevelName(level))
+    gym.logger.set_level(logging.getLevelName(level) + 10)
     for ch in rlberry.logger.handlers:
         ch.setLevel(level)
 

--- a/rlberry/utils/torch.py
+++ b/rlberry/utils/torch.py
@@ -4,7 +4,7 @@ import shutil
 from subprocess import check_output, run, PIPE
 import numpy as np
 import torch
-import logging
+
 
 import rlberry
 

--- a/rlberry/utils/torch.py
+++ b/rlberry/utils/torch.py
@@ -31,7 +31,7 @@ cannot select device with most least memory used."
 
     memory_map = get_gpu_memory_map()
     device_id = np.argmin(memory_map)
-    logger.info(
+    logger.debug(
         f"Choosing GPU device: {device_id}, " f"memory used: {memory_map[device_id]}"
     )
     return torch.device("cuda:{}".format(device_id))
@@ -52,7 +52,7 @@ def choose_device(preferred_device, default_device="cpu"):
         try:
             preferred_device = least_used_device()
         except RuntimeError:
-            logger.info(
+            logger.debug(
                 f"Could not find least used device (nvidia-smi might be missing), use cuda:0 instead"
             )
             if torch.cuda.is_available():
@@ -62,7 +62,7 @@ def choose_device(preferred_device, default_device="cpu"):
     try:
         torch.zeros((1,), device=preferred_device)  # Test availability
     except (RuntimeError, AssertionError) as e:
-        logger.info(
+        logger.debug(
             f"Preferred device {preferred_device} unavailable ({e})."
             f"Switching to default {default_device}"
         )

--- a/rlberry/utils/torch.py
+++ b/rlberry/utils/torch.py
@@ -6,7 +6,9 @@ import numpy as np
 import torch
 import logging
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 def get_gpu_memory_map():

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -306,13 +306,13 @@ class DefaultWriter:
                 df["max_global_step"] = [max_global_step]
 
                 data_message = df.to_string(index=False, justify="center").split("\n")
-                if len(data_message[0]) < size_term:
-                    message = data_message[0].center(shutil.get_terminal_size().columns)
+
+                if len(data_message[0]) < size_term - 14:
+                    message = data_message[0].center(size_term - 14).rstrip() + "\n"
                     message += (
-                        data_message[1]
-                        .center(shutil.get_terminal_size().columns)
-                        .rstrip()
+                        " " * 14 + data_message[1].center(size_term - 14).rstrip()
                     )
+                    # The -14 comes from the info  message
                 else:
                     self._style_log = "one_line"
             if self._style_log == "one_line":

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -1,4 +1,3 @@
-import logging
 import numpy as np
 import pandas as pd
 from collections import deque

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -10,7 +10,9 @@ from rlberry import metadata_utils
 if check_packages.TENSORBOARD_INSTALLED:
     from torch.utils.tensorboard import SummaryWriter
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class DefaultWriter:

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -307,7 +307,9 @@ class DefaultWriter:
 
                 data_message = df.to_string(index=False, justify="center").split("\n")
 
-                if len(data_message[0]) < size_term - 14:
+                if (len(data_message[0]) < size_term - 14) and (
+                    len(data_message[1]) < size_term - 14
+                ):
                     message = data_message[0].center(size_term - 14).rstrip() + "\n"
                     message += (
                         " " * 14 + data_message[1].center(size_term - 14).rstrip()

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -5,6 +5,7 @@ from typing import Optional
 from timeit import default_timer as timer
 from rlberry import check_packages
 from rlberry import metadata_utils
+import shutil
 
 if check_packages.TENSORBOARD_INSTALLED:
     from torch.utils.tensorboard import SummaryWriter
@@ -29,6 +30,8 @@ class DefaultWriter:
         If True, print logs to stderr.
     log_interval : int
         Minimum number of seconds between consecutive logs (with logging module).
+    style_log: str
+        Possible values are "multi_line" and "one_line". Define the style of the logs.
     tensorboard_kwargs : Optional[dict]
         Parameters for tensorboard SummaryWriter. If provided, DefaultWriter
         will behave as tensorboard.SummaryWriter, and will keep utilities to handle
@@ -46,6 +49,7 @@ class DefaultWriter:
         self,
         name: str,
         print_log: bool = True,
+        style_log: str = "multi_line",
         log_interval: int = 3,
         tensorboard_kwargs: Optional[dict] = None,
         execution_metadata: Optional[metadata_utils.ExecutionMetadata] = None,
@@ -59,6 +63,8 @@ class DefaultWriter:
         self._data = None
         self._time_last_log = None
         self._log_time = True
+        assert style_log in ["multi_line", "one_line"], "Style log for writer unknown."
+        self._style_log = style_log
         self._maxlen = maxlen
         self._maxlen_by_tag = maxlen_by_tag
         self.reset()
@@ -283,19 +289,49 @@ class DefaultWriter:
         # log if enough time has passed since the last log
         max_global_step = 0
         if time_elapsed > self._log_interval:
-            self._time_last_log = t_now
-            message = ""
-            for tag in self._data:
-                val = self._data[tag]["value"][-1]
-                gstep = self._data[tag]["global_step"][-1]
-                message += f"{tag} = {val} | "
-                if not np.isnan(gstep):
-                    max_global_step = max(max_global_step, gstep)
 
-            header = self._name
-            if self._execution_metadata:
-                header += f"[worker: {self._execution_metadata.obj_worker_id}]"
-            message = f"[{header}] | max_global_step = {max_global_step} | " + message
+            self._time_last_log = t_now
+            size_term = shutil.get_terminal_size().columns
+
+            if self._style_log == "multi_line":
+                df = pd.DataFrame()
+                df["agent_name"] = [self._name]
+                if self._execution_metadata:
+                    df["worker"] = [self._execution_metadata.obj_worker_id]
+                for tag in self._data:
+                    df[tag] = [np.around(self._data[tag]["value"][-1], 3)]
+                    gstep = self._data[tag]["global_step"][-1]
+                    if not np.isnan(gstep):
+                        max_global_step = max(max_global_step, gstep)
+                df["max_global_step"] = [max_global_step]
+
+                data_message = df.to_string(index=False, justify="center").split("\n")
+                if len(data_message[0]) < size_term:
+                    message = data_message[0].center(shutil.get_terminal_size().columns)
+                    message += (
+                        data_message[1]
+                        .center(shutil.get_terminal_size().columns)
+                        .rstrip()
+                    )
+                else:
+                    self._style_log = "one_line"
+            if self._style_log == "one_line":
+                self._time_last_log = t_now
+                message = ""
+                for tag in self._data:
+                    val = self._data[tag]["value"][-1]
+                    gstep = self._data[tag]["global_step"][-1]
+                    message += f"{tag} = {val} | "
+                    if not np.isnan(gstep):
+                        max_global_step = max(max_global_step, gstep)
+
+                header = self._name
+                if self._execution_metadata:
+                    header += f"[worker: {self._execution_metadata.obj_worker_id}]"
+                message = (
+                    f"[{header}] | max_global_step = {max_global_step} | " + message
+                )
+
             logger.info(message)
 
     def __getattr__(self, attr):

--- a/rlberry/wrappers/uncertainty_estimator_wrapper.py
+++ b/rlberry/wrappers/uncertainty_estimator_wrapper.py
@@ -5,7 +5,9 @@ import logging
 import numpy as np
 from rlberry.utils.factory import load
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class UncertaintyEstimatorWrapper(Wrapper):

--- a/rlberry/wrappers/uncertainty_estimator_wrapper.py
+++ b/rlberry/wrappers/uncertainty_estimator_wrapper.py
@@ -1,7 +1,7 @@
 import torch
 
 from rlberry.envs import Wrapper
-import logging
+
 import numpy as np
 from rlberry.utils.factory import load
 

--- a/rlberry/wrappers/vis2d.py
+++ b/rlberry/wrappers/vis2d.py
@@ -7,7 +7,9 @@ import logging
 import matplotlib.pyplot as plt
 import numpy as np
 
-logger = logging.getLogger(__name__)
+import rlberry
+
+logger = rlberry.logger
 
 
 class Transition:

--- a/rlberry/wrappers/vis2d.py
+++ b/rlberry/wrappers/vis2d.py
@@ -3,7 +3,7 @@ from rlberry.exploration_tools.discrete_counter import DiscreteCounter
 from matplotlib.backends.backend_agg import FigureCanvasAgg as FigureCanvas
 from rlberry.rendering.utils import video_write
 import gym.spaces as spaces
-import logging
+
 import matplotlib.pyplot as plt
 import numpy as np
 


### PR DESCRIPTION
In this PR I make the following changes:

- There is now one logger `rlberry.logger`. It is used everywhere instead of `logging.getLogger(__name__)`. This allows us to handle logging more easily in child processes when doing multiprocessing. This fix the bug that the level could not be changed before.
- The level is fixed usind `rlberry.utils.logging.set_level`.
- The level of worker process in `AgentManager` can still be changes and it can be different from the main logger level.
- I changed the level of some of the messages to be debug
- I added a kind of progress bar for evaluation when level is info (one point = one evaluation)
- I made it so that when we are at info level, gym is at warning. And when we are at debug, gym is at info. And when we are at notset (minimal level), gym is at debug (gym's minimal level)

Example:

<details><summary>Python code</summary>

```python
from rlberry.utils.logging import set_level
from rlberry.agents.torch import A2CAgent
from rlberry.manager import AgentManager, evaluate_agents
from rlberry.envs import gym_make
import numpy as np
from rlberry.agents.torch.utils.training import model_factory_from_env
import numpy as np

set_level('DEBUG')

# Using parameters from deeprl quick start
policy_configs = {
    "type": "MultiLayerPerceptron",  # A network architecture
    "layer_sizes": (64, 64),  # Network dimensions
    "reshape": False,
    "is_policy": True,
}

critic_configs = {
    "type": "MultiLayerPerceptron",
    "layer_sizes": (64, 64),
    "reshape": False,
    "out_size": 1,
}
n_steps = 5e3
batch_size= 128


if __name__=="__main__":

    manager = AgentManager(
        A2CAgent,
        (gym_make, dict(id="CartPole-v1")),
        agent_name="A2CAgent",
        init_kwargs=dict(
            policy_net_fn=model_factory_from_env,
            policy_net_kwargs=policy_configs,
            value_net_fn=model_factory_from_env,
            value_net_kwargs=critic_configs,
            entr_coef=0.0,
            batch_size=1024,
            optimizer_type="ADAM",
            learning_rate=1e-3,
        ),
        fit_budget=3e4,
        eval_kwargs=dict(eval_horizon=500),
        n_fit=2,
        parallelization="process",
        mp_context="spawn",
        seed=42,
         )
    manager.fit()
    outputs = evaluate_agents([manager], n_simulations=20, choose_random_agents=False, show=False)
    manager.fit()
```

</details>

Results when in DEBUG level :
![debug](https://user-images.githubusercontent.com/30346931/178701154-2eafe2de-b56b-4971-8577-56f769929be0.gif)

Results when INFO level:
![info2](https://user-images.githubusercontent.com/30346931/178709989-f383ea69-a283-4fe9-baa2-e529ea2eb3cc.gif)


Any comment are welcome.
