### PR TITLE
feat (plot) add smoothing, tensorboard style

### DIFF
--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -295,7 +295,8 @@ def plot_writer_data(
     title=None,
     savefig_fname=None,
     sns_kwargs=None,
-    smooth_weight=0.0,
+    smooth_weight=0.09,
+    plot_raw_curves=True,
 ):
     """
     Given a list of AgentManager or a folder, plot data (corresponding to info) obtained in each episode.
@@ -343,10 +344,11 @@ def plot_writer_data(
         the figure is not saved.
     sns_kwargs: dict
         Optional extra params for seaborn lineplot.
-
     smooth_weight: float in [0,1], default=0.9
         Apply smoothing tensorboard-style to the plots with parameter smooth_weight.
         Only applied if there is one simulation only.
+    plot_raw_curves: bool, default=True
+        If True and if the curves are smoothed, plot also the unsmoothed curves.
 
     Returns
     -------
@@ -405,15 +407,15 @@ def plot_writer_data(
         return df
 
     if len(data["n_simu"].unique()) == 1:
-        sns.lineplot(x=xx, y="value", hue="name", data=data, ax=ax, alpha=0.3)
+        legends = []
+        if plot_raw_curves:
+            sns.lineplot(x=xx, y="value", hue="name", data=data, ax=ax, alpha=0.3)
+            legends += ["raw " + str(n) for n in data["name"].unique()]
         data = data.groupby(["name"]).apply(_smooth)
         lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax)
         lineplot_kwargs.update(sns_kwargs)
         sns.lineplot(**lineplot_kwargs)
-        ax.legend(
-            ["raw " + str(n) for n in data["name"].unique()]
-            + ["smoothed " + str(n) for n in data["name"].unique()]
-        )
+        ax.legend(legends + ["smoothed " + str(n) for n in data["name"].unique()])
     else:
         lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax, ci="sd")
         lineplot_kwargs.update(sns_kwargs)

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -295,7 +295,7 @@ def plot_writer_data(
     title=None,
     savefig_fname=None,
     sns_kwargs=None,
-    smooth_weight=0.9,
+    smooth_weight=0.0,
 ):
     """
     Given a list of AgentManager or a folder, plot data (corresponding to info) obtained in each episode.
@@ -405,13 +405,15 @@ def plot_writer_data(
         return df
 
     if len(data["n_simu"].unique()) == 1:
-        sns.lineplot(
-            x=xx, y="value", hue="name", data=data, ax=ax, alpha=0.3, legend=False
-        )
+        sns.lineplot(x=xx, y="value", hue="name", data=data, ax=ax, alpha=0.3)
         data = data.groupby(["name"]).apply(_smooth)
         lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax)
         lineplot_kwargs.update(sns_kwargs)
         sns.lineplot(**lineplot_kwargs)
+        ax.legend(
+            ["raw " + str(n) for n in data["name"].unique()]
+            + ["smoothed " + str(n) for n in data["name"].unique()]
+        )
     else:
         lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax, ci="sd")
         lineplot_kwargs.update(sns_kwargs)

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -107,3 +107,13 @@ def test_plot_writer_data_with_directory_input(outdir_id_style):
         )
 
         assert np.all(output.shape == output_with_list_dirs.shape)
+
+        output = plot_writer_data(
+            data_source,
+            tag="reward",
+            xtag="dw_time_elapsed",
+            preprocess_func=_compute_reward,
+            title="Cumulative Reward",
+            show=False,
+            savefig_fname=tmpdirname + "/test.png",
+        )


### PR DESCRIPTION
This PR make it so that the plot is smooth in `plot_writer_data` when there have been only one fit.

Example of result : 
![image](https://user-images.githubusercontent.com/30346931/179987909-36a94b6c-40e3-4dfc-92af-8ef407a95a68.png)

There is a parameter `smooth_weight` in `plot_writer_data` to regulate the amount of smoothing.