### PR TITLE
pyproject, remove poetry deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,24 +6,6 @@ authors = ["rlberry team"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.8,<3.11"
-scipy = "^1.8.1"
-pygame = "^2.1.2"
-matplotlib = "^3.5.2"
-seaborn = "^0.11.2"
-pandas = "^1.4.2"
-gym = "0.21.0"
-dill = "^0.3.5"
-docopt = "^0.6.2"
-PyYAML = "^6.0"
-optuna = "^2.10.0"
-ffmpeg-python = "^0.2.0"
-PyOpenGL = "^3.1.6"
-PyVirtualDisplay = "^3.0"
-torch = "^1.11.0"
-tensorboard = "^2.9.0"
-stable-baselines3 = "^1.5.0"
-protobuf = "3.20.1"
 
 [tool.poetry.dev-dependencies]
 


### PR DESCRIPTION

Remove dependencies in poetry as this conflict with normal pip install.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
- \[ ] I have commented my code, particularly in hard-to-understand areas
- \[ ] I have made corresponding changes to the documentation
- \[ ] I have added tests that prove my fix is effective or that my feature works
- \[ ] New and existing unit tests pass locally with my changes
- \[ ] I have set the label "ready for review" and the checks are all green
-->
