### PR TITLE
fix seaborn compatibility issue

### DIFF
--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -461,8 +461,9 @@ def plot_writer_data(
     if "style" in sns_kwargs:
         # Number of unique dash styles. Default: 4 styles max.
         n_uniq_dash = sns_kwargs.get("n_uniq_dash", 4)
+        linestyles = ["", (1, 1), (5, 5), (1, 5, 3, 5)]
         # Cycle through default sns linestyles.
-        dash_cycler = cycle(sns._core.unique_dashes(n_uniq_dash))
+        dash_cycler = cycle(linestyles[:n_uniq_dash])
         sns_kwargs["dashes"] = [
             next(dash_cycler) for _ in range(data["name"].unique().size)
         ]


### PR DESCRIPTION
Fix a conflict with seaborn last version. Should also fix the ci tests.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
- \[ ] I have commented my code, particularly in hard-to-understand areas
- \[ ] I have made corresponding changes to the documentation
- \[ ] I have added tests that prove my fix is effective or that my feature works
- \[ ] New and existing unit tests pass locally with my changes
- \[ ] I have set the label "ready for review" and the checks are all green
-->
