### PR TITLE
[MRG] fix bug dill and compress always

### DIFF
--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -86,7 +86,7 @@ class Agent(ABC):
         env: types.Env = None,
         eval_env: Optional[types.Env] = None,
         copy_env: bool = True,
-        compress_pickle: bool = False,
+        compress_pickle: bool = True,
         seeder: Optional[types.Seed] = None,
         output_dir: Optional[str] = None,
         _execution_metadata: Optional[metadata_utils.ExecutionMetadata] = None,

--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -8,6 +8,7 @@ import pickle
 import bz2
 import _pickle as cPickle
 from itertools import cycle
+import dill
 
 from rlberry.manager import AgentManager
 import rlberry


### PR DESCRIPTION
Fix a bug with dill and switch compress pickle env to True by default.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
- \[ ] I have commented my code, particularly in hard-to-understand areas
- \[ ] I have made corresponding changes to the documentation
- \[ ] I have added tests that prove my fix is effective or that my feature works
- \[ ] New and existing unit tests pass locally with my changes
- \[ ] I have set the label "ready for review" and the checks are all green
-->
