### PR TITLE
Gym make and evals

### DIFF
--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -103,7 +103,7 @@ class Agent(ABC):
         self.compress_pickle = compress_pickle
         # evaluation environment
         eval_env = eval_env or env
-        self.eval_env = process_env(eval_env, self.seeder, copy_env=True)
+        self.eval_env = process_env(eval_env, self.seeder, copy_env=copy_env)
 
         # metadata
         self._execution_metadata = (

--- a/rlberry/envs/gym_make.py
+++ b/rlberry/envs/gym_make.py
@@ -27,7 +27,7 @@ def gym_make(id, wrap_spaces=False, **kwargs):
     if "module_import" in kwargs:
         __import__(kwargs.pop("module_import"))
 
-    env = gym.make(id,**kwargs)
+    env = gym.make(id, **kwargs)
     return Wrapper(env, wrap_spaces=wrap_spaces)
 
 

--- a/rlberry/envs/gym_make.py
+++ b/rlberry/envs/gym_make.py
@@ -1,5 +1,6 @@
 import gym
 from rlberry.envs.basewrapper import Wrapper
+import numpy as np
 
 
 def gym_make(id, wrap_spaces=False, **kwargs):
@@ -26,22 +27,60 @@ def gym_make(id, wrap_spaces=False, **kwargs):
     """
     if "module_import" in kwargs:
         __import__(kwargs.pop("module_import"))
-    env = gym.make(id)
-    try:
-        env.configure(kwargs)
-    except AttributeError:
-        pass
+    env = gym.make(id,**kwargs)
     return Wrapper(env, wrap_spaces=wrap_spaces)
 
 
-def atari_make(id, scalarize=True, **kwargs):
+def atari_make(id, scalarize=None, **kwargs):
     from stable_baselines3.common.env_util import make_atari_env
     from stable_baselines3.common.vec_env import VecFrameStack
 
-    env = make_atari_env(env_id=id, **kwargs)
+    if scalarize is None:
+        if "n_envs" in kwargs.keys():
+            scalarize = False
+        else:
+            scalarize = True
+
+    if "atari_wrappers_dict" in kwargs.keys():
+        atari_wrappers_dict = kwargs["atari_wrappers_dict"]
+        kwargs.pop("atari_wrappers_dict", None)
+    else:
+        atari_wrappers_dict = dict(
+            terminal_on_life_loss=False
+        )  # hack, some errors with the "terminal_on_life_loss" wrapper : The 'false reset' can lead to make a step on a 'done' environment, then a crash.
+
+    env = make_atari_env(env_id=id, wrapper_kwargs=atari_wrappers_dict, **kwargs)
+
     env = VecFrameStack(env, n_stack=4)
+    env = AtariImageToPyTorch(env)
     if scalarize:
         from rlberry.wrappers.scalarize import ScalarizeEnvWrapper
 
         env = ScalarizeEnvWrapper(env)
     return env
+
+
+class AtariImageToPyTorch(Wrapper):
+    """
+    #transform the observation shape.
+    from: n_env, height, width, chan
+    to: n_env, chan, width, height
+    """
+
+    def __init__(self, env):
+        super(AtariImageToPyTorch, self).__init__(env)
+        old_shape = self.observation_space.shape
+        new_shape = (old_shape[-1], old_shape[0], old_shape[1])
+        self.observation_space = gym.spaces.Box(
+            low=0.0, high=1.0, shape=new_shape, dtype=np.float32
+        )
+
+    def observation(self, observation):
+        return np.transpose(observation, (0, 3, 2, 1))  # transform
+
+    def reset(self):
+        return self.observation(self.env.reset())
+
+    def step(self, action):
+        next_obs, reward, done, info = self.env.step(action)
+        return self.observation(next_obs), reward, done, info


### PR DESCRIPTION

## Description
don't force the copy for the eval
create the env and configure it in 1 line in the gym_make
<!---
## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
- \[ ] I have commented my code, particularly in hard-to-understand areas
- \[ ] I have made corresponding changes to the documentation
- \[ ] I have added tests that prove my fix is effective or that my feature works
- \[ ] New and existing unit tests pass locally with my changes
- \[ ] I have set the label "ready for review" and the checks are all green
-->
