### PR TITLE
Seaborn quantiles errorbar

### DIFF
--- a/rlberry/manager/evaluation.py
+++ b/rlberry/manager/evaluation.py
@@ -9,9 +9,11 @@ import bz2
 import _pickle as cPickle
 from itertools import cycle
 import dill
+from distutils.version import LooseVersion
 
 from rlberry.manager import AgentManager
 import rlberry
+
 
 logger = rlberry.logger
 
@@ -369,7 +371,8 @@ def plot_writer_data(
     Given a list of AgentManager or a folder, plot data (corresponding to info) obtained in each episode.
     The dictionary returned by agents' .fit() method must contain a key equal to `info`.
 
-    If there are several simulations, a confidence interval is plotted.
+    If there are several simulations, a confidence interval is plotted ( 90% percentile interval if seaborn version >= 0.12.0
+    otherwise standard deviation is used). This can be overridden using `sns_kwargs`.
     If there is only one simulation, a tensorboard-style smoothing is performed.
 
     Parameters
@@ -507,7 +510,21 @@ def plot_writer_data(
         sns.lineplot(**lineplot_kwargs)
         ax.legend(legends + ["smoothed " + str(n) for n in data["name"].unique()])
     else:
-        lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax, ci="sd")
+        if LooseVersion(sns.__version__) >= LooseVersion("0.12.0"):
+            if "errorbar" in sns_kwargs.keys():
+                lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax)
+            else:
+                # See https://seaborn.pydata.org/tutorial/error_bars
+                lineplot_kwargs = dict(
+                    x=xx, y="value", hue="name", data=data, ax=ax, errorbar=("pi", 90)
+                )
+        else:
+            if "ci" in sns_kwargs.keys():
+                lineplot_kwargs = dict(x=xx, y="value", hue="name", data=data, ax=ax)
+            else:
+                lineplot_kwargs = dict(
+                    x=xx, y="value", hue="name", data=data, ax=ax, ci="sd"
+                )
         lineplot_kwargs.update(sns_kwargs)
         sns.lineplot(**lineplot_kwargs)
     ax.set_title(title)

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -64,6 +64,29 @@ def test_plot_writer_data_with_manager_input(outdir_id_style):
         assert len(output) > 1
 
 
+def test_ci():
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        output_dir = tmpdirname + "/rlberry_data"
+        manager = _create_and_fit_agent_manager(output_dir, None)
+        os.system("ls " + tmpdirname + "/rlberry_data/manager_data")
+
+        # Plot of the cumulative reward
+        data_source = manager
+        output = plot_writer_data(
+            data_source,
+            tag="reward",
+            preprocess_func=_compute_reward,
+            title="Cumulative Reward",
+            show=False,
+            savefig_fname=tmpdirname + "/test.png",
+            sns_kwargs={"errorbar": "sd"},
+        )
+        assert (
+            os.path.getsize(tmpdirname + "/test.png") > 1000
+        ), "plot_writer_data saved an empty image"
+        assert len(output) > 1
+
+
 @pytest.mark.parametrize("outdir_id_style", ["timestamp"])
 def test_plot_writer_data_with_directory_input(outdir_id_style):
     with tempfile.TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION

## Description

By default, if the version of seaborn is sufficient, use a 90% percentile error bar as default.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401"
- \[ ] I have commented my code, particularly in hard-to-understand areas
- \[ ] I have made corresponding changes to the documentation
- \[ ] I have added tests that prove my fix is effective or that my feature works
- \[ ] New and existing unit tests pass locally with my changes
- \[ ] I have set the label "ready for review" and the checks are all green
-->
