### PR TITLE
Improved PPO (WIP)

### DIFF
--- a/rlberry/agents/torch/ppo/ppo.py
+++ b/rlberry/agents/torch/ppo/ppo.py
@@ -98,8 +98,8 @@ class PPOAgent(AgentWithSimplePolicy):
     eval_horizon : int
         Maximum number of steps per episode during evaluation.
     eval_freq : int
-        Number of updates between evaluations. If None, eval_freq is set to
-        budget // 10 when fit() is called.
+        Number of updates between evaluations. If None, no evaluation is
+        performed.
     device: str
         Device on which to put the tensors. 'cuda:best' by default.
 
@@ -288,7 +288,6 @@ class PPOAgent(AgentWithSimplePolicy):
 
         if lr_scheduler is None:
             lr_scheduler = self._get_lr_scheduler(budget)
-        eval_freq = self.eval_freq or (budget // 10)
         timesteps_counter = 0
 
         episode_returns = np.zeros(self.n_envs, dtype=np.float32)
@@ -352,7 +351,11 @@ class PPOAgent(AgentWithSimplePolicy):
             episode_lengths += 1
 
             # evaluation
-            if self.writer and self.total_timesteps % eval_freq == 0:
+            if (
+                self.writer
+                and self.eval_freq is not None
+                and self.total_timesteps % self.eval_freq == 0
+            ):
                 evaluation = self.eval(
                     eval_horizon=self.eval_horizon,
                     n_simulations=self.n_eval_episodes,

--- a/rlberry/agents/torch/ppo/ppo.py
+++ b/rlberry/agents/torch/ppo/ppo.py
@@ -103,7 +103,6 @@ class PPOAgent(AgentWithSimplePolicy):
     device: str
         Device on which to put the tensors. 'cuda:best' by default.
 
-
     References
     ----------
     Schulman, J., Wolski, F., Dhariwal, P., Radford, A. & Klimov, O. (2017).
@@ -114,7 +113,7 @@ class PPOAgent(AgentWithSimplePolicy):
     "Trust region policy optimization."
     In International Conference on Machine Learning (pp. 1889-1897).
 
-    Flet-Berliac, Y. , Ouhamma, R., Maillard, O.-A., Preux, P. (2021)
+    Flet-Berliac, Y., Ouhamma, R., Maillard, O.-A., Preux, P. (2021)
     "Learning Value Functions in Deep Policy Gradients using Residual Variance."
     In 9th International Conference on Learning Representations (ICLR).
     """

--- a/rlberry/agents/torch/ppo/ppo_utils.py
+++ b/rlberry/agents/torch/ppo/ppo_utils.py
@@ -1,0 +1,222 @@
+import copy
+import logging
+
+import gym
+import numpy as np
+
+from rlberry.envs.utils import process_env
+from rlberry.utils.jit_setup import numba_jit
+
+
+logger = logging.getLogger(__name__)
+
+
+def process_ppo_env(env, seeder, num_envs=1, asynchronous=False):
+    """
+    Process environment for PPO. It is the only agent that supports vectorized
+    environments.
+
+    Parameters
+    ----------
+    env : gym.Env
+        Environment to be processed.
+    seeder : rlberry.Seeder
+        Seeder object.
+    num_envs : int
+        Number of environments to be used.
+    asynchronous : bool
+        If True, the environments are run asynchronously.
+
+    Returns
+    -------
+    vec_env : gym.vector.VectorEnv
+        Vectorized environment.
+    """
+    vec_env_cls = (
+        gym.vector.AsyncVectorEnv if asynchronous else gym.vector.SyncVectorEnv
+    )
+    return vec_env_cls(
+        [lambda: process_env(env, seeder, copy_env=True) for _ in range(num_envs)]
+    )
+
+
+# @numba_jit
+# def lambda_returns(r_t, discount_t, v_tp1, lambda_):
+#     """
+#     Computer lambda returns
+#     Parameters
+#     ----------
+#     r_t: array
+#         Array of shape (time_dim, batch_dim) containing the rewards.
+#     discount_t: array
+#         Array of shape (time_dim, batch_dim) containing the discounts (0.0 if terminal state).
+#     v_tp1: array
+#         Array of shape (time_dim, batch_dim) containing the values at timestep t+1
+#     lambda_ : float in [0, 1]
+#         Lambda-returns parameter.
+#     """
+#     print('lamda_returns')
+#     T = v_tp1.shape[0]
+#     returns = np.zeros_like(r_t)
+#     aux = v_tp1[-1]
+#     for tt in range(T):
+#         i = T - tt - 1
+#         print(i, r_t[i], aux, discount_t[i], v_tp1[i])
+#         aux = r_t[i] + discount_t[i] * (
+#             (1 - lambda_) * v_tp1[i] + lambda_ * aux)
+#         returns[i] = aux
+#         print(returns[i])
+#     return returns
+
+
+@numba_jit
+def lambda_returns(r_t, terminal_tp1, v_tp1, gamma, lambda_):
+    """
+    Compute lambda returns.
+
+    Parameters
+    ----------
+    r_t: array
+        Array of shape (time_dim, batch_dim) containing the rewards.
+    terminal_tp1: array
+        Array of shape (time_dim, batch_dim) containing the discounts (0.0 if terminal state).
+    v_tp1: array
+        Array of shape (time_dim, batch_dim) containing the values at timestep t+1
+    lambda_ : float in [0, 1]
+        Lambda-returns parameter.
+    """
+    T = v_tp1.shape[0]
+    returns = np.zeros_like(r_t)
+    aux = v_tp1[-1].astype(np.float32)
+    for tt in range(T):
+        i = T - tt - 1
+        returns[i] = r_t[i] + gamma * (1 - terminal_tp1[i]) * (
+            (1 - lambda_) * v_tp1[i] + lambda_ * aux
+        )
+        aux = returns[i]
+    return returns
+
+
+class RolloutBuffer:
+    """
+    Rollout buffer that allows sampling data with shape (batch_size,
+    num_trajectories, ...).
+    Parameters
+    ----------
+    rng: numpy.random.Generator
+        Numpy random number generator.
+        See https://numpy.org/doc/stable/reference/random/generator.html
+    max_episode_steps: int, optional
+        Maximum length of an episode
+    """
+
+    def __init__(self, rng, num_rollout_steps):
+        self._rng = rng
+        self._num_rollout_steps = num_rollout_steps
+        self._curr_step = 0
+        self._tags = []
+        self._data = dict()
+        self._dtypes = dict()
+
+    @property
+    def data(self):
+        """Dict containing all stored data."""
+        return self._data
+
+    @property
+    def tags(self):
+        """Tags identifying the entries in the replay buffer."""
+        return self._tags
+
+    @property
+    def dtypes(self):
+        """Dict containing the data types for each tag."""
+        return self._dtypes
+
+    @property
+    def num_rollout_steps(self):
+        """Number of steps to take in each environment per policy rollout."""
+        return self._num_rollout_steps
+
+    @property
+    def num_envs(self):
+        return self._num_envs
+
+    def __len__(self):
+        return self._curr_step
+
+    def full(self):
+        """Returns True if the buffer is full."""
+        return len(self) == self.num_rollout_steps
+
+    def clear(self):
+        """Clear data in replay."""
+        self._curr_step = 0
+        for tag in self._data:
+            self._data[tag] = None
+
+    def setup_entry(self, tag, dtype):
+        """Configure replay buffer to store data.
+        Parameters
+        ----------
+        tag : str
+            Tag that identifies the entry (e.g "observation", "reward")
+        dtype : obj
+            Data type of the entry (e.g. `np.float32`). Type is not
+            checked in :meth:`append`, but it is used to construct the numpy
+            arrays returned by the :meth:`sample`method.
+        """
+        assert len(self) == 0, "Cannot setup entry on non-empty buffer."
+        if tag in self._data:
+            raise ValueError(f"Entry {tag} already added to replay buffer.")
+        self._tags.append(tag)
+        self._dtypes[tag] = dtype
+        self._data[tag] = None
+
+    def append(self, data):
+        """
+        Stores data from an environment step in the buffer.
+
+        Parameters
+        ----------
+        data : dict
+            Dictionary containing scalar values, whose keys must be in self.tags.
+        """
+        assert set(data.keys()) == set(self.tags), "Data keys must be in self.tags"
+        assert len(self) < self.num_rollout_steps, "Buffer is full."
+        for tag in self.tags:
+            #
+            if self._data[tag] is None:
+                if isinstance(data[tag], np.ndarray):
+                    # if data[tag].dtype != self._dtypes[tag]:
+                    #     logger.warning(
+                    #         f"Data type for tag {tag} is {data[tag].dtype}, "
+                    #         f"but it was configured as {self._dtypes[tag]}.")
+                    shape = data[tag].shape
+                    self._data[tag] = np.zeros(
+                        (self.num_rollout_steps, *shape), dtype=self._dtypes[tag]
+                    )
+                elif isinstance(data[tag], float) or isinstance(data[tag], int):
+                    self._data[tag] = np.zeros(
+                        self.num_rollout_steps, dtype=self._dtypes[tag]
+                    )
+                else:
+                    self._data[tag] = [None] * self.num_rollout_steps
+            self._data[tag][self._curr_step] = data[tag]
+        self._curr_step += 1
+
+    def get(self):
+        """
+        Returns the collected data. If the appended data for a given tag is a
+        numpy array, the returned data will be a numpy array of shape:
+
+        (T, *S), where T is the number of rollout steps, and S is the shape of
+        the data that was appended.
+
+        Otherwise, the returned data will be a list of length T.
+
+        Returns
+        -------
+        Returns a dict with the collected data.
+        """
+        return copy.deepcopy(self._data)

--- a/rlberry/agents/torch/ppo/ppo_utils.py
+++ b/rlberry/agents/torch/ppo/ppo_utils.py
@@ -40,35 +40,6 @@ def process_ppo_env(env, seeder, num_envs=1, asynchronous=False):
     )
 
 
-# @numba_jit
-# def lambda_returns(r_t, discount_t, v_tp1, lambda_):
-#     """
-#     Computer lambda returns
-#     Parameters
-#     ----------
-#     r_t: array
-#         Array of shape (time_dim, batch_dim) containing the rewards.
-#     discount_t: array
-#         Array of shape (time_dim, batch_dim) containing the discounts (0.0 if terminal state).
-#     v_tp1: array
-#         Array of shape (time_dim, batch_dim) containing the values at timestep t+1
-#     lambda_ : float in [0, 1]
-#         Lambda-returns parameter.
-#     """
-#     print('lamda_returns')
-#     T = v_tp1.shape[0]
-#     returns = np.zeros_like(r_t)
-#     aux = v_tp1[-1]
-#     for tt in range(T):
-#         i = T - tt - 1
-#         print(i, r_t[i], aux, discount_t[i], v_tp1[i])
-#         aux = r_t[i] + discount_t[i] * (
-#             (1 - lambda_) * v_tp1[i] + lambda_ * aux)
-#         returns[i] = aux
-#         print(returns[i])
-#     return returns
-
-
 @numba_jit
 def lambda_returns(r_t, terminal_tp1, v_tp1, gamma, lambda_):
     """

--- a/rlberry/agents/torch/tests/test_ppo.py
+++ b/rlberry/agents/torch/tests/test_ppo.py
@@ -108,7 +108,6 @@ def test_ppo():
         init_kwargs=dict(
             batch_size=24,
             n_steps=96,
-            use_gae=False,
             policy_net_fn="rlberry.agents.torch.utils.training.model_factory_from_env",
             policy_net_kwargs=dict(
                 type="MultiLayerPerceptron",
@@ -139,7 +138,6 @@ def test_ppo():
         init_kwargs=dict(
             batch_size=24,
             n_steps=96,
-            use_gae=False,
             policy_net_fn=model_factory_from_env,
             policy_net_kwargs=dict(
                 type="MultiLayerPerceptron",
@@ -173,7 +171,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(100),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96, normalize_rewards=True),
+        init_kwargs=dict(batch_size=24, n_steps=96),
         n_fit=1,
         agent_name="PPO_rlberry_" + "PBall2D",
     )
@@ -197,3 +195,7 @@ def test_ppo():
 
     output = evaluate_agents([pporlberry_stats], n_simulations=2, plot=False)
     pporlberry_stats.clear_output_dir()
+
+
+if __name__ == "__main__":
+    test_ppo()

--- a/rlberry/agents/torch/utils/models.py
+++ b/rlberry/agents/torch/utils/models.py
@@ -462,6 +462,7 @@ class ConvolutionalNetwork(nn.Module):
         x = self.activation((self.conv1(x)))
         x = self.activation((self.conv2(x)))
         x = self.activation((self.conv3(x)))
+        x = x.view(x.size(0), -1)
         return x
 
     def forward(self, x):

--- a/rlberry/agents/torch/utils/models.py
+++ b/rlberry/agents/torch/utils/models.py
@@ -1,8 +1,10 @@
 #
 # Simple MLP and CNN models
 #
-import numpy as np
+from functools import partial
+
 from gym import spaces
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
@@ -175,17 +177,19 @@ class BaseModule(torch.nn.Module):
         - normalization parameters
     """
 
-    def __init__(self, activation_type="RELU", reset_type="XAVIER"):
+    def __init__(self, activation_type="RELU", reset_type="xavier"):
         super().__init__()
         self.activation = activation_factory(activation_type)
         self.reset_type = reset_type
 
-    def _init_weights(self, m):
+    def _init_weights(self, m, param=None):
         if hasattr(m, "weight"):
-            if self.reset_type == "XAVIER":
+            if self.reset_type == "xavier":
                 torch.nn.init.xavier_uniform_(m.weight.data)
-            elif self.reset_type == "ZEROS":
+            elif self.reset_type == "zeros":
                 torch.nn.init.constant_(m.weight.data, 0.0)
+            elif self.reset_type == "orthogonal":
+                torch.nn.init.orthogonal_(m.weight.data, gain=param)
             else:
                 raise ValueError("Unknown reset type")
         if hasattr(m, "bias") and m.bias is not None:
@@ -221,27 +225,6 @@ class Table(torch.nn.Module):
         return self.policy(x.long())
 
 
-def orthogonal_layer_init(layer, std=np.log(2), bias=0.0):
-    """Initialize a layer with orthogonal weights and a given bias.
-
-    Parameters
-    ----------
-    layer: torch.nn.Linear
-        Layer to initialize
-    std: float
-        Standard deviation of the weights
-    bias: float
-        Bias of the layer
-
-    Returns
-    -------
-    layer: torch.nn.Linear
-    """
-    torch.nn.init.orthogonal_(layer.weight, std)
-    torch.nn.init.constant_(layer.bias, bias)
-    return layer
-
-
 class MultiLayerPerceptron(BaseModule):
     """Torch module for an MLP.
 
@@ -259,13 +242,21 @@ class MultiLayerPerceptron(BaseModule):
     activation: {"RELU", "TANH", "ELU"}
         Activation function.
     is_policy: bool, default=False
-        If true, the :meth:`forward` method returns a categorical
-        distribution corresponding to the softmax of the output.
+        If true, the :meth:`forward` method returns a distribution over the
+        output.
+    ctns_actions: bool, default=False
+        If true, the :meth:`forward` method returns a normal distribution
+        corresponding to the output. Otherwise, a categorical distribution
+        is returned.
+    std0: float, default=1.0
+        Initial standard deviation for the normal distribution. Only used
+        if ctns_actions and is_policy are True.
+    reset_type: {"xavier", "orthogonal", "zeros"}, default="orthogonal"
+        Type of weight initialization.
+    pred_init_scale: float, default="auto"
+        Scale of the initial weights of the output layer. If "auto", the
+        scale is set to 0.01 for policy networks and 1.0 otherwise.
     """
-
-    __layer_init__ = {
-        "orthogonal": orthogonal_layer_init,
-    }
 
     def __init__(
         self,
@@ -277,11 +268,12 @@ class MultiLayerPerceptron(BaseModule):
         is_policy=False,
         ctns_actions=False,
         std0=1.0,
-        layer_init="orthogonal",
-        predict_init_std="auto",
+        reset_type="orthogonal",
+        pred_init_scale="auto",
         **kwargs
     ):
-        super().__init__(**kwargs)
+        super().__init__(reset_type=reset_type, **kwargs)
+
         self.reshape = reshape
         self.layer_sizes = layer_sizes or [64, 64]
         self.layer_sizes = list(self.layer_sizes)
@@ -290,26 +282,25 @@ class MultiLayerPerceptron(BaseModule):
         self.is_policy = is_policy
         self.ctns_actions = ctns_actions
         self.std0 = std0
-        self.layer_init = layer_init
-        self.predict_init_std = predict_init_std
+        self.pred_init_scale = pred_init_scale
 
         sizes = [in_size] + self.layer_sizes
-        if layer_init is not None:
-            assert layer_init in self.__layer_init__, "Unknown layer init"
-            init = self.__layer_init__[layer_init]
-        else:
-            init = lambda l: l
-
-        layers_list = [
-            init(nn.Linear(sizes[i], sizes[i + 1])) for i in range(len(sizes) - 1)
-        ]
-        self.layers = nn.ModuleList(layers_list)
+        self.layers = nn.ModuleList(
+            [nn.Linear(sizes[i], sizes[i + 1]) for i in range(len(sizes) - 1)]
+        )
         if out_size:
             if ctns_actions:
                 self.logstd = nn.Parameter(np.log(std0) * torch.ones(out_size))
-            if predict_init_std == "auto":
-                predict_init_std = 0.01 if self.is_policy else 1.0
-            self.predict = init(nn.Linear(sizes[-1], out_size), std=predict_init_std)
+            self.predict = nn.Linear(sizes[-1], out_size)
+        self.reset()
+
+    def reset(self):
+        self.apply(partial(self._init_weights, param=np.log(2)))
+        if self.pred_init_scale == "auto":
+            pred_init_scale = 0.01 if self.is_policy else 1.0
+        else:
+            pred_init_scale = self.pred_init_scale
+        self._init_weights(self.predict, param=pred_init_scale)
 
     def forward(self, x):
         if self.reshape:
@@ -462,7 +453,7 @@ class ConvolutionalNetwork(nn.Module):
         x = self.activation((self.conv1(x)))
         x = self.activation((self.conv2(x)))
         x = self.activation((self.conv3(x)))
-        x = x.view(x.size(0), -1)
+        x = x.view(x.size(0), -1)  # flatten
         return x
 
     def forward(self, x):

--- a/rlberry/agents/torch/utils/models.py
+++ b/rlberry/agents/torch/utils/models.py
@@ -271,7 +271,7 @@ class MultiLayerPerceptron(BaseModule):
         self,
         in_size=None,
         layer_sizes=None,
-        reshape=True,
+        reshape=False,
         out_size=None,
         activation="RELU",
         is_policy=False,


### PR DESCRIPTION
## Description

Recently, I tried to reproduce [mujoco](https://github.com/deepmind/mujoco) benchmarks with rlberry's PPO and failed to achieve the expected results. This PR implements a series of improvements to PPO in the hope to recover the expected returns on continuous control benchmarks.

References for the implementation:
* [The 37 Implementation Details of Proximal Policy Optimization](https://iclr-blog-track.github.io/2022/03/25/ppo-implementation-details/).
* [StableBaselines3](https://github.com/DLR-RM/stable-baselines3), [CleanRL](https://github.com/vwxyzjn/cleanrl), and [MushroomRL](https://github.com/MushroomRL/mushroom-rl).
* [What Matters for On-Policy Deep Actor-Critic Methods? A Large-Scale Study, Andrychowicz et al. (2021)](https://arxiv.org/abs/2006.05990)

## Changes

* **New RolloutBuffer class.** Instead of using a replay buffer from DQN, now PPO uses a specialized RolloutBuffer to store experience. This is slightly more performant and clearer to the reader.
* **Support for vectorized environments.** The new implementation supports vectorized environments using the `n_envs` keyword argument of `PPOAgent`. Note that `env` is still a single environment, in line with other rlberry agents, but PPO now internally creates a vectorized environment. As a result, the entire implementation supposes an extra dimension for the environment (important for future reference).
* **Support for evaluation.** The agent has kwargs `n_eval_episodes`, `eval_horizon` and `eval_freq` which can be used to setup an evaluation procedure during training.
* **Support for layer initialization.** Following recommendations in Andrychowicz et al. (2021), this PR implements orthogonal layer initialization for MLPs, as well as a custom weight initialization scale for the last layer with `predict_init_std`. Using `predict_init_std="auto"` when creating a policy or value function will initialize the weights of the last layers according to the recommendations, that is, `std=1.0` for value nets and `std=0.01` for policy nets.
* **Support for learning rate annealing.** This new implementation supports the most used form of learning rate annealing, which is linear decay, and customizable learning rate schedules.
* **Support for other value losses** In addition to the standard MSE loss (`mse`) for the value net, this PR also adds support for the clipped value loss of the original PPO implementation (`clipped`) and the AVEC (Y. Flet-Berliac et al., 2021) loss (`avec`).  These can be changed via the `value_loss` kwargs.
* **Add `target_kl` configuration.** Implementation of early stopping of the PPO update epochs if the estimated KL divergence of the policies exceeds a given value.
* **Add `max_grad_norm` configuration.** In the original implementation, PPO rescales the gradients of the policy and value network so that the “global l2 norm” (i.e., the norm of the concatenated gradients of all parameters) does not exceed a given value (0.5 by default). This added option implements this functionality.
* **Optimized Advantage Computation.** This PR implements and uses a `lambda_returns` function that is JIT compiled with `numba` in order to compute advantages.
* **Add logging metrics.** Adds more metrics to the logging, such as `approx_kl` and `clipratio`.
* **Fix to continuous actions implementation.** Previously, a fixed standard deviation was used for the Gaussian action distribution. This PR implements the state-independent log standard deviation parameter, which is the most commonly used. The initial value for this parameter can be changed via the `std0` kwarg of the policy.
* **Removal of the `old_policy`.** The original implementation had a copy of the policy network to compute the old action log probabilities, but this new implementation avoids this by doing a forward pass on the policy network before updating and saving and reusing those results.
* **Removal of the `use_gae` configuration.** Following other implementations, GAE is used by default with PPO.
* **Removal of the `normalize_reward` configuration.** Reward normalization should be implemented via the appropriate `gym` wrapper.
* **Overall Rewrite.** A lot of logic was rewritten in a new style, inspired by [CleanRL](https://github.com/vwxyzjn/cleanrl) and [our own DQN](https://github.com/rlberry-py/rlberry/blob/main/rlberry/agents/torch/dqn/dqn.py).

## Notes

There are a few questions to answer after this PR:

* **Model Factory**: the code for the model factory is slowly gathering implementation details from all agents and it's getting more and more confusing. We should think about a better way of implementing this.
* **Learning Rate Scheduler**: for now, the learning rate schedule is a bit of a hack - but we can maybe integrate it more natively to rlberry. 
* **Native VecEnv Support**: PPO implements VecEnvs only for itself, which means the code can't be used in other agents. Maybe we can add native VecEnv support to rlberry so it's easier to create agents that support VecEnvs. This probably should be done *after* the migration to `gymnasium`.

