### PR TITLE
Add Q-learning and SARSA agents

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -50,6 +50,8 @@ Basic Agents
    :toctree: generated/
    :template: class.rst
 
+   agents.QLAgent
+   agents.SARSAAgent
    agents.ValueIterationAgent
    agents.MBQVIAgent
    agents.UCBVIAgent

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 
 Dev version
 -----------
+*PR #306*
+
+* Add Q-learning agent in :class:`rlberry.agents.QLAgent` and SARSA agent in :class:`rlberry.agents.SARSAAgent`.
+
 *PR #298*
 
 * Move old scripts (jax agents, attention networks, old examples...) that we won't maintain from the main branch to an archive branch.

--- a/rlberry/_version.py
+++ b/rlberry/_version.py
@@ -1,1 +1,1 @@
-__version__ = "v0.4.0.post24.dev0+69363af "
+__version__ = "v0.4.0.post26.dev0+11a1189 "

--- a/rlberry/agents/__init__.py
+++ b/rlberry/agents/__init__.py
@@ -13,3 +13,4 @@ from .optql import OptQLAgent
 from .psrl import PSRLAgent
 from .rlsvi import RLSVIAgent
 from .ucbvi import UCBVIAgent
+from .tabular_rl import QLAgent, SARSAAgent

--- a/rlberry/agents/adaptiveql/adaptiveql.py
+++ b/rlberry/agents/adaptiveql/adaptiveql.py
@@ -18,7 +18,7 @@ class AdaptiveQLAgent(AgentWithSimplePolicy):
     Parameters
     ----------
     env : gym.Env
-        Environment with discrete states and actions.
+        Environment with continuous states and discrete actions.
     gamma : double, default: 1.0
         Discount factor in [0, 1].
     horizon : int

--- a/rlberry/agents/tabular_rl/__init__.py
+++ b/rlberry/agents/tabular_rl/__init__.py
@@ -1,0 +1,2 @@
+from .qlearning import QLAgent
+from .sarsa import SARSAAgent

--- a/rlberry/agents/tabular_rl/qlearning.py
+++ b/rlberry/agents/tabular_rl/qlearning.py
@@ -1,51 +1,80 @@
+from typing import Optional, Literal
 import numpy as np
-from rlberry.agents import AgentWithSimplePolicy
 from gym import spaces
 from scipy.special import softmax
 
+from rlberry import types
+from rlberry.agents import AgentWithSimplePolicy
 
 
 class QLAgent(AgentWithSimplePolicy):
+    """Q-Learning Agent.
+
+    Parameters
+    ----------
+    env: :class:`~rlberry.types.Env`
+        Environment with discrete states and actions.
+    gamma: float, default = 0.99
+        Discount factor.
+    alpha: float, default = 0.1
+        Learning rate.
+    exploration_type: {"epsilon", "boltzmann"}, default: None
+        If "epsilon": Epsilon-Greedy exploration.
+        If "boltzmann": Boltzmann exploration.
+        If None: No exploration.
+    exploration_rate: float, default: None
+        epsilon parameter for Epsilon-Greedy exploration or tau parameter for Boltzmann exploration.
+    """
+
     name = "QL"
 
-    def __init__(self, env, gamma=0.99, alpha=0.1, epsilon=None, tau=None, **kwargs):
+    def __init__(
+        self,
+        env: types.Env,
+        gamma: float = 0.99,
+        alpha: float = 0.1,
+        exploration_type: Optional[Literal["epsilon", "boltzmann"]] = None,
+        exploration_rate: Optional[float] = None,
+        **kwargs
+    ):
         # init base class
         AgentWithSimplePolicy.__init__(self, env, **kwargs)
 
         self.gamma = gamma
-        self.eps = epsilon
-        self.tau = tau
         self.alpha = alpha
+        self.exploration_type = exploration_type
+        self.exploration_rate = exploration_rate
         # check environment
         assert isinstance(self.env.observation_space, spaces.Discrete)
         assert isinstance(self.env.action_space, spaces.Discrete)
-        assert (self.eps is not None and self.tau is None) or (
-            self.tau is not None and self.eps is None
-        )
-        # initialize
-        self.reset()
+
+        # check exploration type
+        if self.exploration_type is not None:
+            assert (
+                exploration_type == "epsilon" or "boltzmann"
+            ) and exploration_rate is not None
+
+        self.Q = np.zeros((self.env.observation_space.n, self.env.action_space.n))
 
     def reset(self, **kwargs):
-        S = self.env.observation_space.n
-        A = self.env.action_space.n
-        self.Q = np.zeros((S, A))
+        self.Q.fill(0)
 
     def policy(self, observation):
-        """Recommended policy."""
-        s = observation
-        return self.Q[s].argmax()
+        return self.Q[observation].argmax()
 
-    def get_action(self, s):
-        if self.eps:
-            if np.random.random() <= self.eps:
-                a = np.random.choice(self.env.action_space.n)
-            else:
-                a = self.Q[s].argmax()
-        else:
-            a = np.random.choice(
-                self.env.action_space.n, p=softmax(self.tau * self.Q[s])
+    def get_action(self, observation):
+        if (
+            self.exploration_type == "epsilon"
+            and np.random.random() <= self.exploration_rate
+        ):
+            return np.random.choice(self.env.action_space.n)
+        elif self.exploration_type == "boltzmann":
+            return np.random.choice(
+                self.env.action_space.n,
+                p=softmax(self.exploration_rate * self.Q[observation]),
             )
-        return a
+        else:
+            return self.Q[observation].argmax()
 
     def fit(self, budget: int, **kwargs):
         """
@@ -56,22 +85,23 @@ class QLAgent(AgentWithSimplePolicy):
             number of Q updates.
         """
         del kwargs
-        s = self.env.reset()
-        cumul_r = 0
+        observation = self.env.reset()
+        episode_rewards = 0
         for i in range(budget):
-            a = self.get_action(s)
-            snext, r, done, _ = self.env.step(a)
-            cumul_r += r
+            action = self.get_action(observation)
+            next_observation, reward, done, _ = self.env.step(action)
+            episode_rewards += reward
             if self.writer is not None:
-                self.writer.add_scalar("cumul_reward", cumul_r, i)
-
+                self.writer.add_scalar("episode_rewards", episode_rewards, i)
             if done:
-                self.Q[s, a] = r
+                self.Q[observation, action] = reward
             else:
-                self.Q[s, a] = self.Q[s, a] + self.alpha * (
-                    r + self.gamma * np.amax(self.Q[snext]) - self.Q[s, a]
+                self.Q[observation, action] = self.Q[observation, action] + self.alpha * (
+                        reward
+                        + self.gamma * np.amax(self.Q[next_observation])
+                        - self.Q[observation, action]
                 )
-            s = snext
+            observation = next_observation
             if done:
-                s = self.env.reset()
-                cumul_r = 0
+                observation = self.env.reset()
+                episode_rewards = 0

--- a/rlberry/agents/tabular_rl/qlearning.py
+++ b/rlberry/agents/tabular_rl/qlearning.py
@@ -1,0 +1,77 @@
+import numpy as np
+from rlberry.agents import AgentWithSimplePolicy
+from gym import spaces
+from scipy.special import softmax
+
+
+
+class QLAgent(AgentWithSimplePolicy):
+    name = "QL"
+
+    def __init__(self, env, gamma=0.99, alpha=0.1, epsilon=None, tau=None, **kwargs):
+        # init base class
+        AgentWithSimplePolicy.__init__(self, env, **kwargs)
+
+        self.gamma = gamma
+        self.eps = epsilon
+        self.tau = tau
+        self.alpha = alpha
+        # check environment
+        assert isinstance(self.env.observation_space, spaces.Discrete)
+        assert isinstance(self.env.action_space, spaces.Discrete)
+        assert (self.eps is not None and self.tau is None) or (
+            self.tau is not None and self.eps is None
+        )
+        # initialize
+        self.reset()
+
+    def reset(self, **kwargs):
+        S = self.env.observation_space.n
+        A = self.env.action_space.n
+        self.Q = np.zeros((S, A))
+
+    def policy(self, observation):
+        """Recommended policy."""
+        s = observation
+        return self.Q[s].argmax()
+
+    def get_action(self, s):
+        if self.eps:
+            if np.random.random() <= self.eps:
+                a = np.random.choice(self.env.action_space.n)
+            else:
+                a = self.Q[s].argmax()
+        else:
+            a = np.random.choice(
+                self.env.action_space.n, p=softmax(self.tau * self.Q[s])
+            )
+        return a
+
+    def fit(self, budget: int, **kwargs):
+        """
+        Train the agent using the provided environment.
+        Parameters
+        ----------
+        budget: int
+            number of Q updates.
+        """
+        del kwargs
+        s = self.env.reset()
+        cumul_r = 0
+        for i in range(budget):
+            a = self.get_action(s)
+            snext, r, done, _ = self.env.step(a)
+            cumul_r += r
+            if self.writer is not None:
+                self.writer.add_scalar("cumul_reward", cumul_r, i)
+
+            if done:
+                self.Q[s, a] = r
+            else:
+                self.Q[s, a] = self.Q[s, a] + self.alpha * (
+                    r + self.gamma * np.amax(self.Q[snext]) - self.Q[s, a]
+                )
+            s = snext
+            if done:
+                s = self.env.reset()
+                cumul_r = 0

--- a/rlberry/agents/tabular_rl/qlearning.py
+++ b/rlberry/agents/tabular_rl/qlearning.py
@@ -24,6 +24,21 @@ class QLAgent(AgentWithSimplePolicy):
         If None: No exploration.
     exploration_rate: float, default: None
         epsilon parameter for Epsilon-Greedy exploration or tau parameter for Boltzmann exploration.
+
+    Attributes
+    ----------
+    Q : ndarray
+        2D array that stores the estimation ofexpected rewards for state-action pairs.
+
+    Examples
+    --------
+    >>> from rlberry.envs import GridWorld
+    >>>
+    >>> env = GridWorld(walls=(), nrows=5, ncols=5)
+    >>> agent = QLAgent()
+    >>> agent.fit(budget=1000)
+    >>> agent.policy(env.observation_space.sample())
+    >>> agent.reset()
     """
 
     name = "QL"

--- a/rlberry/agents/tabular_rl/sarsa.py
+++ b/rlberry/agents/tabular_rl/sarsa.py
@@ -1,0 +1,78 @@
+import numpy as np
+from rlberry.agents import AgentWithSimplePolicy
+from gym import spaces
+from scipy.special import softmax
+
+
+class SARSAAgent(AgentWithSimplePolicy):
+    name = "SARSA"
+
+    def __init__(self, env, gamma=0.99, alpha=0.1, epsilon=None, tau=None, **kwargs):
+        # init base class
+        AgentWithSimplePolicy.__init__(self, env, **kwargs)
+
+        self.gamma = gamma
+        self.eps = epsilon
+        self.tau = tau
+        self.alpha = alpha
+        # check environment
+        assert isinstance(self.env.observation_space, spaces.Discrete)
+        assert isinstance(self.env.action_space, spaces.Discrete)
+        assert (self.eps is not None and self.tau is None) or (
+            self.tau is not None and self.eps is None
+        )
+        # initialize
+        self.reset()
+
+    def reset(self, **kwargs):
+        S = self.env.observation_space.n
+        A = self.env.action_space.n
+        self.Q = np.zeros((S, A))
+
+    def policy(self, observation):
+        """Recommended policy."""
+        s = observation
+        return self.Q[s].argmax()
+
+    def get_action(self, s):
+        if self.eps:
+            if np.random.random() <= self.eps:
+                a = np.random.choice(self.env.action_space.n)
+            else:
+                a = self.Q[s].argmax()
+        else:
+            a = np.random.choice(
+                self.env.action_space.n, p=softmax(self.tau * self.Q[s])
+            )
+        return a
+
+    def fit(self, budget: int, **kwargs):
+        """
+        Train the agent using the provided environment.
+        Parameters
+        ----------
+        budget: int
+            number of Q updates.
+        """
+        del kwargs
+        s = self.env.reset()
+        cumul_r = 0
+        for i in range(budget):
+            a = self.get_action(s)
+            snext, r, done, _ = self.env.step(a)
+            cumul_r += r
+            anext = self.get_action(snext)
+
+            if self.writer is not None:
+                self.writer.add_scalar("cumul_reward", cumul_r, i)
+
+            if done:
+                self.Q[s, a] = r
+            else:
+                self.Q[s, a] = self.Q[s, a] + self.alpha * (
+                    r + self.gamma * self.Q[snext, anext] - self.Q[s, a]
+                )
+            s = snext
+            if done:
+                s = self.env.reset()
+                cumul_r = 0

--- a/rlberry/agents/tabular_rl/sarsa.py
+++ b/rlberry/agents/tabular_rl/sarsa.py
@@ -24,6 +24,20 @@ class SARSAAgent(AgentWithSimplePolicy):
         If None: No exploration.
     exploration_rate: float, default: None
         epsilon parameter for Epsilon-Greedy exploration or tau parameter for Boltzmann exploration.
+
+    Attributes
+    ----------
+    Q : ndarray
+        2D array that stores the estimation ofexpected rewards for state-action pairs.
+    Examples
+    --------
+    >>> from rlberry.envs import GridWorld
+    >>>
+    >>> env = GridWorld(walls=(), nrows=5, ncols=5)
+    >>> agent = SARSAAgent()
+    >>> agent.fit(budget=1000)
+    >>> agent.policy(env.observation_space.sample())
+    >>> agent.reset()
     """
 
     def __init__(

--- a/rlberry/agents/tests/test_tabular_rl.py
+++ b/rlberry/agents/tests/test_tabular_rl.py
@@ -1,14 +1,39 @@
+import pytest
 from rlberry.agents import QLAgent, SARSAAgent
 from rlberry.envs import GridWorld
 
 
-def test_ql():
-    env = GridWorld()
-    agent = QLAgent(env, epsilon=0.3)
-    agent.fit(budget=2)
+@pytest.mark.parametrize(
+    "exploration_type, exploration_rate",
+    [
+        ("epsilon", 0.5),
+        ("boltzmann", 0.5),
+        (None, None)
+    ],
+)
+def test_ql(exploration_type, exploration_rate):
+    env = GridWorld(walls=(), nrows=5, ncols=5)
+    agent = QLAgent(env, exploration_type=exploration_type, exploration_rate=exploration_rate)
+    agent.fit(budget=50)
+    agent.policy(env.observation_space.sample())
+    agent.reset()
+    assert not agent.Q.any()
 
 
-def test_sarsa():
-    env = GridWorld()
-    agent = SARSAAgent(env, epsilon=0.3)
-    agent.fit(budget=2)
+@pytest.mark.parametrize(
+    "exploration_type, exploration_rate",
+    [
+        ("epsilon", 0.5),
+        ("boltzmann", 0.5),
+        (None, None)
+    ],
+)
+def test_sarsa(exploration_type, exploration_rate):
+    env = GridWorld(walls=(), nrows=5, ncols=5)
+    agent = SARSAAgent(env, exploration_type=exploration_type, exploration_rate=exploration_rate)
+    agent.fit(budget=50)
+    agent.policy(env.observation_space.sample())
+    agent.reset()
+    assert not agent.Q.any()
+
+

--- a/rlberry/agents/tests/test_tabular_rl.py
+++ b/rlberry/agents/tests/test_tabular_rl.py
@@ -1,0 +1,14 @@
+from rlberry.agents import QLAgent, SARSAAgent
+from rlberry.envs import GridWorld
+
+
+def test_ql():
+    env = GridWorld()
+    agent = QLAgent(env, epsilon=0.3)
+    agent.fit(budget=2)
+
+
+def test_sarsa():
+    env = GridWorld()
+    agent = SARSAAgent(env, epsilon=0.3)
+    agent.fit(budget=2)

--- a/rlberry/tests/test_agents_base.py
+++ b/rlberry/tests/test_agents_base.py
@@ -44,6 +44,8 @@ class OneHotLSVI(agents.LSVIUCBAgent):
 
 
 FINITE_MDP_AGENTS = [
+    agents.QLAgent,
+    agents.SARSAAgent,
     agents.ValueIterationAgent,
     agents.MBQVIAgent,
     agents.UCBVIAgent,


### PR DESCRIPTION
## Description

This PR add 2 tabular agents: Q-Learning and SARSA (continuity of #254).

## TODO 

Add 1 example for qlearning and 1 for sarsa. (video plot)

<!---
## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have commented my code, particularly in hard-to-understand areas,
- \[x] I have made corresponding changes to the documentation,
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
