### PR TITLE
fix gym to fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pygame
 matplotlib
 seaborn
 pandas
-gym[accept-rom-licens] @ git+https://github.com/rlberry-py/gym_fix_021
+gym[accept-rom-license] @ git+https://github.com/rlberry-py/gym_fix_021
 dill
 docopt
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pygame
 matplotlib
 seaborn
 pandas
-gym[accept-rom-license]==0.21.0
+git+https://github.com/rlberry-py/gym_fix_021[accept-rom-license]
 dill
 docopt
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pygame
 matplotlib
 seaborn
 pandas
-git+https://github.com/rlberry-py/gym_fix_021[accept-rom-license]
+gym[accept-rom-licens] @ git+https://github.com/rlberry-py/gym_fix_021
 dill
 docopt
 pyyaml

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.17
 scipy>=1.6
-pygame
+pygame-ce
 matplotlib
 seaborn
 pandas

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "matplotlib",
     "seaborn",
     "pandas",
-    "gym[accept-rom-license]==0.21.0",
+    "git+https://github.com/rlberry-py/gym_fix_021[accept-rom-license]",
     "dill",
     "docopt",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ packages = find_packages(exclude=["docs", "notebooks", "assets"])
 install_requires = [
     "numpy>=1.17",
     "scipy>=1.6",
-    "pygame",
+    "pygame-ce",
     "matplotlib",
     "seaborn",
     "pandas",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "matplotlib",
     "seaborn",
     "pandas",
-    "gym[accept-rom-licens] @ git+https://github.com/rlberry-py/gym_fix_021",
+    "gym[accept-rom-license] @ git+https://github.com/rlberry-py/gym_fix_021",
     "dill",
     "docopt",
     "pyyaml",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     "matplotlib",
     "seaborn",
     "pandas",
-    "git+https://github.com/rlberry-py/gym_fix_021[accept-rom-license]",
+    "gym[accept-rom-licens] @ git+https://github.com/rlberry-py/gym_fix_021",
     "dill",
     "docopt",
     "pyyaml",


### PR DESCRIPTION

## Description

There is a bug that affect the compatibility between new setuptools and gym 0.21 (see https://github.com/openai/gym/issues/3200) hence gym 0.21 is not installable anymore with the new setuptools.

Because I don't think it is a good idea to fix setuptools version, I made a fork of gym 0.21 and I did the fix on this fork. I propose we use this fork to install gym in rlberry. 

fork here: https://github.com/rlberry-py/gym_fix_021

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
