### PR TITLE
[MRG] implement queues in stochastic bandits

### DIFF
--- a/rlberry/envs/bandits/corrupted_bandits.py
+++ b/rlberry/envs/bandits/corrupted_bandits.py
@@ -14,6 +14,7 @@ class CorruptedLaws:
         Can either be a frozen scipy law or any class that
         has a method .rvs() to sample according to the given law.
 
+
     cor_prop: float in (0,1/2)
         Proportion of corruption
 
@@ -26,12 +27,11 @@ class CorruptedLaws:
         self.cor_prop = cor_prop
         self.cor_law = cor_law
 
-    def rvs(self, random_state):
-        is_corrupted = random_state.binomial(1, self.cor_prop)
-        if is_corrupted == 1:
-            return self.cor_law.rvs(random_state=random_state)
-        else:
-            return self.law.rvs(random_state=random_state)
+    def rvs(self, size, random_state):
+        is_corrupted = random_state.binomial(1, self.cor_prop, size=size)
+        cor_sample = self.cor_law.rvs(size=size, random_state=random_state)
+        noncor_sample = self.law.rvs(size=size, random_state=random_state)
+        return is_corrupted * cor_sample + (1 - is_corrupted) * noncor_sample
 
     def mean(self):
         return (


### PR DESCRIPTION

## Description

This PR implements a simple queuing system for bandits, pre-sampling the laws at geometric intervals for each arm for faster computation.

For example, in the ucb example, the fit time was 4.13s and with this PR it becomes 2.9s .



<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
