### PR TITLE
[minor changes] New CI,  "Optuna" in Check-agent, and "profile.prof" .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,6 +72,7 @@ coverage.xml
 *.py,cover
 .hypothesis/
 .pytest_cache/
+profile.prof
 
 # Translations
 *.mo

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,3 +135,60 @@ jobs:
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest --ignore=rlberry/network
     displayName: 'pytest'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+- job: 'linux_non-editable'
+  dependsOn: checkPrLabel
+  # Condition: have ready for review label or on the main branch.
+  condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
+  pool:
+    vmImage: ubuntu-latest
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.9'
+  variables:
+    NUMBA_DISABLE_JIT: "1"
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  # - script: |
+  #     python -m pip install --upgrade pip
+  #     pip install -r requirements.txt
+  #     sudo apt install libglu1-mesa
+  - script: |
+      python -m pip install --upgrade pip
+      sudo apt install libglu1-mesa
+    displayName: 'Install dependencies'
+  - script: |
+      set -xe
+      pip install .
+    displayName: 'Install rlberry'
+  - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest --ignore=rlberry/network
+    displayName: 'pytest'
+
+
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,34 +138,38 @@ jobs:
 
 
 
-# - job: 'linux_non-editable'
-#   dependsOn: checkPrLabel
-#   # Condition: have ready for review label or on the main branch.
-#   condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
-#   pool:
-#     vmImage: ubuntu-latest
-#   strategy:
-#     matrix:
-#       Python39:
-#         python.version: '3.9'
-#   variables:
-#     NUMBA_DISABLE_JIT: "1"
+- job: 'linux_non_editable'
+  dependsOn: checkPrLabel
+  # Condition: have ready for review label or on the main branch.
+  condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
+  pool:
+    vmImage: ubuntu-latest
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.9'
+  variables:
+    NUMBA_DISABLE_JIT: "1"
 
-#   steps:
-#   - task: UsePythonVersion@0
-#     inputs:
-#       versionSpec: '$(python.version)'
-#     displayName: 'Use Python $(python.version)'
-#   - script: |
-#       python -m pip install --upgrade pip
-#       pip install -r requirements.txt
-#       sudo apt install libglu1-mesa
-#     displayName: 'Install dependencies'
-#   - script: |
-#       set -xe
-#       pip install -e .
-#     displayName: 'Install rlberry'
-#   - script: |
-#       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-#       pytest --ignore=rlberry/network
-#     displayName: 'pytest'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+  - script: |
+      python -m pip install --upgrade pip
+      sudo apt install libglu1-mesa
+    displayName: 'Install dependencies'
+  # - script: |
+  #     python -m pip install --upgrade pip
+  #     pip install -r requirements.txt
+  #     sudo apt install libglu1-mesa
+  #   displayName: 'Install dependencies'
+  - script: |
+      set -xe
+      pip install .
+    displayName: 'Install rlberry'
+  - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest --ignore=rlberry/network
+    displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,22 +138,6 @@ jobs:
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 - job: 'linux_non-editable'
   dependsOn: checkPrLabel
   # Condition: have ready for review label or on the main branch.
@@ -172,20 +156,17 @@ jobs:
     inputs:
       versionSpec: '$(python.version)'
     displayName: 'Use Python $(python.version)'
-
-  # - script: |
-  #     python -m pip install --upgrade pip
-  #     pip install -r requirements.txt
-  #     sudo apt install libglu1-mesa
   - script: |
       python -m pip install --upgrade pip
+      pip install -r requirements.txt
       sudo apt install libglu1-mesa
     displayName: 'Install dependencies'
   - script: |
       set -xe
-      pip install .
+      pip install -e .
     displayName: 'Install rlberry'
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest --ignore=rlberry/network
     displayName: 'pytest'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,10 +171,7 @@ jobs:
       --ignore=rlberry/network \
       --ignore=rlberry/agents/torch \
       --ignore=rlberry/agents/experimental \
-      --ignore=rlberry/agents/tests/test_adaptiveql.py \
-      --ignore=rlberry/agents/tests/test_bandits.py \
-      --ignore=rlberry/agents/tests/test_dynprog.py \
-      --ignore=rlberry/agents/tests/test_stable_baselines.py \
+      --ignore=rlberry/agents/tests \
       --ignore=rlberry/experiment/tests/test_experiment_generator.py \
       --ignore=rlberry/experiment/tests/test_load_results.py \
       --ignore=rlberry/exploration_tools/torch \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,7 +171,7 @@ jobs:
       --ignore=rlberry/network \
       --ignore=rlberry/agents/torch \
       --ignore=rlberry/agents/experimental \
-      --ignore=rlberry/agents/tests/test_adaptiveql.py
+      --ignore=rlberry/agents/tests/test_adaptiveql.py \
       --ignore=rlberry/agents/tests/test_bandits.py \
       --ignore=rlberry/agents/tests/test_stable_baselines.py \
       --ignore=rlberry/experiment/tests/test_experiment_generator.py \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,3 +169,70 @@ jobs:
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest rlberry/tests/test_no_extra_install.py
     displayName: 'pytest'
+
+
+
+
+
+
+- job: 'macOS_non_editable'
+  dependsOn: checkPrLabel
+  condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
+
+  pool:
+    vmImage: 'macOS-12'
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.9'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  - script: |
+      python -m pip install --upgrade pip
+    displayName: 'Install dependencies'
+
+  - script: |
+      set -xe
+      pip install .
+    displayName: 'Install rlberry'
+
+  - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest rlberry/tests/test_no_extra_install.py
+    displayName: 'pytest'
+
+- job: 'windows_non_editable'
+  dependsOn: checkPrLabel
+  condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
+  pool:
+    vmImage: 'windows-2022'
+  strategy:
+    matrix:
+      Python39:
+        python.version: '3.9'
+
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+
+  - script: |
+      python -m pip install --upgrade pip
+    displayName: 'Install dependencies'
+
+  - script: |
+      pip wheel . -w dist\
+      pip install --pre --no-index --find-links dist\ rlberry
+    displayName: 'Install rlberry'
+
+  - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest rlberry/tests/test_no_extra_install.py
+    displayName: 'pytest'
+

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
       # run doctests in the documentation
       # TODO: use following line for doctest ?
       pytest docs/*rst || echo "Ignoring exit status"
-      pytest --import-mode=importlib --cov=rlberry --cov-report xml rlberry
+      pytest --import-mode=importlib --cov=rlberry --cov-report xml rlberry --ignore=rlberry/tests/test_no_extra_install.py
     displayName: 'Test and coverage'
   - script: |
       curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -102,7 +102,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network
+      pytest --ignore=rlberry/network --ignore=rlberry/tests/test_no_extra_install.py
     displayName: 'pytest'
 
 - job: 'windows'
@@ -133,7 +133,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network
+      pytest --ignore=rlberry/network --ignore=rlberry/tests/test_no_extra_install.py
     displayName: 'pytest'
 
 
@@ -167,17 +167,5 @@ jobs:
   #ignore les tests qui viennent des extras : torch, experimental, stablebaselines, optuna
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest \
-      --ignore=rlberry/network \
-      --ignore=rlberry/agents/torch \
-      --ignore=rlberry/agents/experimental \
-      --ignore=rlberry/agents/tests \
-      --ignore=rlberry/experiment/tests/test_experiment_generator.py \
-      --ignore=rlberry/experiment/tests/test_load_results.py \
-      --ignore=rlberry/exploration_tools/torch \
-      --ignore=rlberry/manager/tests/test_agent_manager_seeding.py \
-      --ignore=rlberry/manager/tests/test_hyperparam_optim.py \
-      --ignore=rlberry/tests \
-      --ignore=rlberry/utils/tests \
-      --ignore=rlberry/wrappers/tests/test_common_wrappers.py
+      pytest rlberry/tests/test_no_extra_install.py
     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -160,16 +160,25 @@ jobs:
       python -m pip install --upgrade pip
       sudo apt install libglu1-mesa
     displayName: 'Install dependencies'
-  # - script: |
-  #     python -m pip install --upgrade pip
-  #     pip install -r requirements.txt
-  #     sudo apt install libglu1-mesa
-  #   displayName: 'Install dependencies'
   - script: |
       set -xe
       pip install .
     displayName: 'Install rlberry'
+  #ignore les tests qui viennent des extras : torch, experimental, stablebaselines, optuna
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network
+      pytest \
+      --ignore=rlberry/network \
+      --ignore=rlberry/agents/torch \
+      --ignore=rlberry/agents/experimental \
+      --ignore=rlberry/agents/tests/test_bandits.py \
+      --ignore=rlberry/agents/tests/test_stable_baselines.py \
+      --ignore=rlberry/experiment/tests/test_experiment_generator.py \
+      --ignore=rlberry/experiment/tests/test_load_results.py \
+      --ignore=rlberry/exploration_tools/torch \
+      --ignore=rlberry/manager/tests/test_agent_manager_seeding.py \
+      --ignore=rlberry/manager/tests/test_hyperparam_optim.py \
+      --ignore=rlberry/tests \
+      --ignore=rlberry/utils/tests \
+      --ignore=rlberry/wrappers/tests/test_common_wrappers.py 
     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -235,4 +235,3 @@ jobs:
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest rlberry/tests/test_no_extra_install.py
     displayName: 'pytest'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -173,6 +173,7 @@ jobs:
       --ignore=rlberry/agents/experimental \
       --ignore=rlberry/agents/tests/test_adaptiveql.py \
       --ignore=rlberry/agents/tests/test_bandits.py \
+      --ignore=rlberry/agents/tests/test_dynprog.py \
       --ignore=rlberry/agents/tests/test_stable_baselines.py \
       --ignore=rlberry/experiment/tests/test_experiment_generator.py \
       --ignore=rlberry/experiment/tests/test_load_results.py \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -169,4 +169,3 @@ jobs:
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest --ignore=rlberry/network
     displayName: 'pytest'
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -180,5 +180,5 @@ jobs:
       --ignore=rlberry/manager/tests/test_hyperparam_optim.py \
       --ignore=rlberry/tests \
       --ignore=rlberry/utils/tests \
-      --ignore=rlberry/wrappers/tests/test_common_wrappers.py 
+      --ignore=rlberry/wrappers/tests/test_common_wrappers.py
     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,7 +64,7 @@ jobs:
       # run doctests in the documentation
       # TODO: use following line for doctest ?
       pytest docs/*rst || echo "Ignoring exit status"
-      pytest --import-mode=importlib --cov=rlberry --cov-report xml rlberry --ignore=rlberry/tests/test_no_extra_install.py
+      pytest --import-mode=importlib --cov=rlberry --cov-report xml rlberry
     displayName: 'Test and coverage'
   - script: |
       curl -Os https://uploader.codecov.io/latest/linux/codecov
@@ -102,7 +102,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network --ignore=rlberry/tests/test_no_extra_install.py
+      pytest --ignore=rlberry/network 
     displayName: 'pytest'
 
 - job: 'windows'
@@ -133,9 +133,8 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network --ignore=rlberry/tests/test_no_extra_install.py
+      pytest --ignore=rlberry/network 
     displayName: 'pytest'
-
 
 
 - job: 'linux_non_editable'
@@ -167,12 +166,8 @@ jobs:
   #ignore les tests qui viennent des extras : torch, experimental, stablebaselines, optuna
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest rlberry/tests/test_no_extra_install.py
+      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
     displayName: 'pytest'
-
-
-
-
 
 
 - job: 'macOS_non_editable'
@@ -203,7 +198,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest rlberry/tests/test_no_extra_install.py
+      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
     displayName: 'pytest'
 
 - job: 'windows_non_editable'
@@ -232,5 +227,5 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest rlberry/tests/test_no_extra_install.py
+      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,34 +138,34 @@ jobs:
 
 
 
-- job: 'linux_non-editable'
-  dependsOn: checkPrLabel
-  # Condition: have ready for review label or on the main branch.
-  condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
-  pool:
-    vmImage: ubuntu-latest
-  strategy:
-    matrix:
-      Python39:
-        python.version: '3.9'
-  variables:
-    NUMBA_DISABLE_JIT: "1"
+# - job: 'linux_non-editable'
+#   dependsOn: checkPrLabel
+#   # Condition: have ready for review label or on the main branch.
+#   condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
+#   pool:
+#     vmImage: ubuntu-latest
+#   strategy:
+#     matrix:
+#       Python39:
+#         python.version: '3.9'
+#   variables:
+#     NUMBA_DISABLE_JIT: "1"
 
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-    displayName: 'Use Python $(python.version)'
-  - script: |
-      python -m pip install --upgrade pip
-      pip install -r requirements.txt
-      sudo apt install libglu1-mesa
-    displayName: 'Install dependencies'
-  - script: |
-      set -xe
-      pip install -e .
-    displayName: 'Install rlberry'
-  - script: |
-      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network
-    displayName: 'pytest'
+#   steps:
+#   - task: UsePythonVersion@0
+#     inputs:
+#       versionSpec: '$(python.version)'
+#     displayName: 'Use Python $(python.version)'
+#   - script: |
+#       python -m pip install --upgrade pip
+#       pip install -r requirements.txt
+#       sudo apt install libglu1-mesa
+#     displayName: 'Install dependencies'
+#   - script: |
+#       set -xe
+#       pip install -e .
+#     displayName: 'Install rlberry'
+#   - script: |
+#       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+#       pytest --ignore=rlberry/network
+#     displayName: 'pytest'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -227,8 +227,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pip wheel . -w dist\
-      pip install --pre --no-index --find-links dist\ rlberry
+      pip install .
     displayName: 'Install rlberry'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -189,6 +189,3 @@ jobs:
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest --ignore=rlberry/network
     displayName: 'pytest'
-
-
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network 
+      pytest --ignore=rlberry/network
     displayName: 'pytest'
 
 - job: 'windows'
@@ -133,7 +133,7 @@ jobs:
 
   - script: |
       pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest --ignore=rlberry/network 
+      pytest --ignore=rlberry/network
     displayName: 'pytest'
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -171,6 +171,7 @@ jobs:
       --ignore=rlberry/network \
       --ignore=rlberry/agents/torch \
       --ignore=rlberry/agents/experimental \
+      --ignore=rlberry/agents/tests/test_adaptiveql.py
       --ignore=rlberry/agents/tests/test_bandits.py \
       --ignore=rlberry/agents/tests/test_stable_baselines.py \
       --ignore=rlberry/experiment/tests/test_experiment_generator.py \

--- a/codecov.yml
+++ b/codecov.yml
@@ -25,3 +25,4 @@ ignore:
   - "./rlberry/rendering/pygame_render2d.py"
   - "./rlberry/colab_utils/display_setup.py"
   - "./rlberry/agents/experimental/jax/**/*.py"
+  - "./rlberry/network/**/*.py"

--- a/rlberry/agents/torch/tests/test_ppo.py
+++ b/rlberry/agents/torch/tests/test_ppo.py
@@ -29,7 +29,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96),
+        init_kwargs=dict(batch_size=24, n_steps=96, device="cpu"),
         n_fit=1,
         agent_name="PPO_rlberry_" + env,
     )
@@ -49,7 +49,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96),
+        init_kwargs=dict(batch_size=24, n_steps=96, device="cpu"),
         n_fit=1,
         agent_name="PPO_rlberry_" + env,
     )
@@ -69,7 +69,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96),
+        init_kwargs=dict(batch_size=24, n_steps=96, device="cpu"),
         n_fit=1,
         agent_name="PPO_rlberry_" + env,
     )
@@ -86,7 +86,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96),
+        init_kwargs=dict(batch_size=24, n_steps=96, device="cpu"),
         n_fit=1,
         agent_name="PPO_rlberry_" + "PBall2D",
     )
@@ -172,7 +172,7 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96),
+        init_kwargs=dict(batch_size=24, n_steps=96, device="cpu"),
         n_fit=1,
         agent_name="PPO_rlberry_" + "PBall2D",
     )
@@ -187,7 +187,9 @@ def test_ppo():
         (env_ctor, env_kwargs),
         fit_budget=int(132),
         eval_kwargs=dict(eval_horizon=2),
-        init_kwargs=dict(batch_size=24, n_steps=96, normalize_advantages=True),
+        init_kwargs=dict(
+            batch_size=24, n_steps=96, normalize_advantages=True, device="cpu"
+        ),
         n_fit=1,
         agent_name="PPO_rlberry_" + "PBall2D",
     )

--- a/rlberry/tests/test_agent_extra.py
+++ b/rlberry/tests/test_agent_extra.py
@@ -34,6 +34,7 @@ class OneHotLSVI(agents.LSVIUCBAgent):
             self, env, feature_map_fn=feature_map_fn, horizon=10, **kwargs
         )
 
+
 # No agent "FINITE_MDP" in extra
 # FINITE_MDP_AGENTS = [
 # ]

--- a/rlberry/tests/test_agent_extra.py
+++ b/rlberry/tests/test_agent_extra.py
@@ -34,21 +34,12 @@ class OneHotLSVI(agents.LSVIUCBAgent):
             self, env, feature_map_fn=feature_map_fn, horizon=10, **kwargs
         )
 
-
-FINITE_MDP_AGENTS = [
-    agents.ValueIterationAgent,
-    agents.MBQVIAgent,
-    agents.UCBVIAgent,
-    agents.OptQLAgent,
-    agents.PSRLAgent,
-    agents.RLSVIAgent,
-    OneHotLSVI,
-]
+# No agent "FINITE_MDP" in extra
+# FINITE_MDP_AGENTS = [
+# ]
 
 
 CONTINUOUS_STATE_AGENTS = [
-    agents.RSUCBVIAgent,
-    agents.RSKernelUCBVIAgent,
     torch_agents.DQNAgent,
     torch_agents.MunchausenDQNAgent,
     torch_agents.REINFORCEAgent,
@@ -68,11 +59,11 @@ MULTI_ENV_AGENTS = [
     torch_agents.PPOAgent,
 ]
 
-
-@pytest.mark.parametrize("agent", FINITE_MDP_AGENTS)
-def test_finite_state_agent(agent):
-    check_rl_agent(agent, env="discrete_state")
-    check_rlberry_agent(agent, env="discrete_state")
+# No agent "FINITE_MDP" in extra
+# @pytest.mark.parametrize("agent", FINITE_MDP_AGENTS)
+# def test_finite_state_agent(agent):
+#     check_rl_agent(agent, env="discrete_state")
+#     check_rlberry_agent(agent, env="discrete_state")
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="bug with windows???")

--- a/rlberry/tests/test_agents_base.py
+++ b/rlberry/tests/test_agents_base.py
@@ -14,22 +14,10 @@ import sys
 import rlberry.agents as agents
 from rlberry.agents.features import FeatureMap
 
-from rlberry.envs import Acrobot
-from rlberry.envs.benchmarks.ball_exploration import PBall2D
-from rlberry.envs.benchmarks.generalization.twinrooms import TwinRooms
-from rlberry.envs.benchmarks.grid_exploration.apple_gold import AppleGold
-from rlberry.envs.benchmarks.grid_exploration.nroom import NRoom
-from rlberry.envs.classic_control import MountainCar, SpringCartPole
-from rlberry.envs.finite import Chain, GridWorld
-
 from rlberry.utils.check_agent import (
     check_rl_agent,
     check_rlberry_agent,
 )
-from rlberry.utils.check_env import check_env, check_rlberry_env
-
-
-#### TESTS AGENTS ####
 
 
 class OneHotFeatureMap(FeatureMap):
@@ -83,25 +71,3 @@ def test_finite_state_agent(agent):
 def test_continuous_state_agent(agent):
     check_rl_agent(agent, env="continuous_state")
     check_rlberry_agent(agent, env="continuous_state")
-
-
-#### TESTS ENVS ####
-
-
-ALL_ENVS = [
-    Acrobot,
-    PBall2D,
-    TwinRooms,
-    AppleGold,
-    NRoom,
-    MountainCar,
-    Chain,
-    GridWorld,
-    SpringCartPole,
-]
-
-
-@pytest.mark.parametrize("Env", ALL_ENVS)
-def test_env(Env):
-    check_env(Env())
-    check_rlberry_env(Env())

--- a/rlberry/tests/test_no_extra_install.py
+++ b/rlberry/tests/test_no_extra_install.py
@@ -1,0 +1,110 @@
+"""
+===============================================
+Tests for the installation without extra (StableBaselines3, torch, optuna, ...)
+===============================================
+tests based on test_agent.py and test_envs.py
+
+"""
+
+
+import pytest
+import numpy as np
+import sys
+
+import rlberry.agents as agents
+from rlberry.agents.features import FeatureMap
+
+from rlberry.envs import Acrobot
+from rlberry.envs.benchmarks.ball_exploration import PBall2D
+from rlberry.envs.benchmarks.generalization.twinrooms import TwinRooms
+from rlberry.envs.benchmarks.grid_exploration.apple_gold import AppleGold
+from rlberry.envs.benchmarks.grid_exploration.nroom import NRoom
+from rlberry.envs.classic_control import MountainCar, SpringCartPole
+from rlberry.envs.finite import Chain, GridWorld
+
+from rlberry.utils.check_agent import (
+    check_rl_agent,
+    check_rlberry_agent,
+)
+from rlberry.utils.check_env import check_env, check_rlberry_env
+
+
+#### TESTS AGENTS ####
+
+class OneHotFeatureMap(FeatureMap):
+    def __init__(self, S, A):
+        self.S = S
+        self.A = A
+        self.shape = (S * A,)
+
+    def map(self, observation, action):
+        feat = np.zeros((self.S, self.A))
+        feat[observation, action] = 1.0
+        return feat.flatten()
+
+
+# LSVIUCBAgent needs a feature map function to work.
+class OneHotLSVI(agents.LSVIUCBAgent):
+    def __init__(self, env, **kwargs):
+        def feature_map_fn(_env):
+            return OneHotFeatureMap(5, 2)  # values for Chain
+
+        agents.LSVIUCBAgent.__init__(
+            self, env, feature_map_fn=feature_map_fn, horizon=10, **kwargs
+        )
+
+
+FINITE_MDP_AGENTS = [
+    agents.ValueIterationAgent,
+    agents.MBQVIAgent,
+    agents.UCBVIAgent,
+    agents.OptQLAgent,
+    agents.PSRLAgent,
+    agents.RLSVIAgent,
+    OneHotLSVI,
+]
+
+
+CONTINUOUS_STATE_AGENTS = [
+    agents.RSUCBVIAgent,
+    agents.RSKernelUCBVIAgent,
+]
+
+
+
+@pytest.mark.parametrize("agent", FINITE_MDP_AGENTS)
+def test_finite_state_agent(agent):
+    check_rl_agent(agent, env="discrete_state")
+    check_rlberry_agent(agent, env="discrete_state")
+
+
+@pytest.mark.xfail(sys.platform == "win32", reason="bug with windows???")
+@pytest.mark.parametrize("agent", CONTINUOUS_STATE_AGENTS)
+def test_continuous_state_agent(agent):
+    check_rl_agent(agent, env="continuous_state")
+    check_rlberry_agent(agent, env="continuous_state")
+
+
+
+#### TESTS ENVS ####
+
+
+ALL_ENVS = [
+    Acrobot,
+    PBall2D,
+    TwinRooms,
+    AppleGold,
+    NRoom,
+    MountainCar,
+    Chain,
+    GridWorld,
+    SpringCartPole,
+]
+
+
+@pytest.mark.parametrize("Env", ALL_ENVS)
+def test_env(Env):
+    check_env(Env())
+    check_rlberry_env(Env())
+
+

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -314,8 +314,11 @@ def _check_save_load_without_manager(agent, env="continuous_state", init_kwargs=
         params_for_loader = dict(env=train_env)
 
         # extract the class name to check if we need to add some param to load
-        try:           
-            from rlberry.agents.stable_baselines.stable_baselines import StableBaselinesAgent
+        try:
+            from rlberry.agents.stable_baselines.stable_baselines import (
+                StableBaselinesAgent,
+            )
+
             if issubclass(agent, StableBaselinesAgent):
                 params_for_loader["algo_cls"] = init_kwargs["algo_cls"]
         except ModuleNotFoundError:

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -7,7 +7,6 @@ import tempfile
 import os
 from rlberry.envs.gym_make import gym_make
 import pathlib
-from rlberry.agents.stable_baselines.stable_baselines import StableBaselinesAgent
 
 
 SEED = 42
@@ -315,8 +314,12 @@ def _check_save_load_without_manager(agent, env="continuous_state", init_kwargs=
         params_for_loader = dict(env=train_env)
 
         # extract the class name to check if we need to add some param to load
-        if issubclass(agent, StableBaselinesAgent):
-            params_for_loader["algo_cls"] = init_kwargs["algo_cls"]
+        try:           
+            from rlberry.agents.stable_baselines.stable_baselines import StableBaselinesAgent
+            if issubclass(agent, StableBaselinesAgent):
+                params_for_loader["algo_cls"] = init_kwargs["algo_cls"]
+        except ModuleNotFoundError:
+            pass
 
         loaded_agent = agent.load(saving_path, **params_for_loader)
         assert loaded_agent

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -9,7 +9,6 @@ from rlberry.envs.gym_make import gym_make
 import pathlib
 from rlberry.agents.stable_baselines.stable_baselines import StableBaselinesAgent
 
-from optuna.samplers import TPESampler
 
 SEED = 42
 
@@ -536,6 +535,9 @@ def check_hyperparam_optimisation_agent(
 
 
 def _test_hyperparam_optim_tpe(agent, env="continuous_state", init_kwargs=None):
+
+    from optuna.samplers import TPESampler
+
     # Define trainenv
     if init_kwargs is None:
         init_kwargs = {}


### PR DESCRIPTION
PR to add some minor changes

- Add profile.prof into the .gitignore. (Artifact created by testing agent_manager)
- Move the "optuna" import inside the function that needs it, to avoid crashes on other functions (when you don't install optuna).
- Add a CI to test the installation without requirement.txt and without the editable "-e" mode
- Remove the 'network' folder from the code coverage