### PR TITLE
(fix) Change default bias init in Base NN

### DIFF
--- a/rlberry/agents/torch/utils/models.py
+++ b/rlberry/agents/torch/utils/models.py
@@ -190,7 +190,7 @@ class BaseModule(torch.nn.Module):
         self.activation = activation_factory(activation_type)
         self.reset_type = reset_type
 
-    def _init_weights(self, m, param=None):
+    def _init_weights(self, m, param=None, put_bias_to_zero=False):
         if hasattr(m, "weight"):
             if self.reset_type == "xavier":
                 torch.nn.init.xavier_uniform_(m.weight.data)
@@ -200,8 +200,9 @@ class BaseModule(torch.nn.Module):
                 torch.nn.init.orthogonal_(m.weight.data, gain=param)
             else:
                 raise ValueError("Unknown reset type")
-        if hasattr(m, "bias") and m.bias is not None:
-            torch.nn.init.constant_(m.bias.data, 0.0)
+        if put_bias_to_zero:
+            if hasattr(m, "bias") and m.bias is not None:
+                torch.nn.init.constant_(m.bias.data, 0.0)
 
     def reset(self):
         self.apply(self._init_weights)

--- a/rlberry/agents/torch/utils/models.py
+++ b/rlberry/agents/torch/utils/models.py
@@ -316,6 +316,9 @@ class MultiLayerPerceptron(BaseModule):
         if self.out_size:
             if self.ctns_actions:
                 self.logstd.data.fill_(np.log(self.std0))
+                self.apply(
+                    partial(self._init_weights, param=np.log(2), put_bias_to_zero=True)
+                )
             self._init_weights(self.predict, param=self.pred_init_scale)
 
     def forward(self, x):


### PR DESCRIPTION

## Description

PR #290 introduced a reinitialization of the bias to 0 that seems to make the learning much longer in discrete.

@AleShi94 @mmcenta @YannBerthelot

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
