### PR TITLE
Timeout ppo test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ opencv-python
 ale-py==0.7.4
 pytest
 pytest-xprocess
+pytest-timeout

--- a/rlberry/agents/torch/tests/test_ppo.py
+++ b/rlberry/agents/torch/tests/test_ppo.py
@@ -17,6 +17,7 @@ from rlberry.agents.torch.utils.training import model_factory_from_env
 import sys
 
 
+@pytest.mark.timeout(300)
 @pytest.mark.xfail(sys.platform == "win32", reason="bug with windows???")
 def test_ppo():
     env = "CartPole-v0"

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -87,6 +87,7 @@ def test_ci():
         assert len(output) > 1
 
 
+@pytest.mark.xfail(sys.platform == "win32", reason="bug with windows???")
 @pytest.mark.parametrize("outdir_id_style", ["timestamp"])
 def test_plot_writer_data_with_directory_input(outdir_id_style):
     with tempfile.TemporaryDirectory() as tmpdirname:

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -3,7 +3,7 @@ import tempfile
 import os
 import numpy as np
 from pathlib import Path
-
+import sys
 
 from rlberry.wrappers import WriterWrapper
 from rlberry.envs import GridWorld


### PR DESCRIPTION

## Description

Add a timeout to ppo test so that the ci on windows fails faster

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
