### PR TITLE
Add preset manager function

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -168,6 +168,15 @@ Seeding
 Utilities, Logging & Typing
 ===========================
 
+Manager Utilitis
+----------------
+
+.. autosummary::
+   :toctree: generated/
+   :template: function.rst
+   manager.preset_manager
+
+
 Writer Utilities
 ----------------
 

--- a/rlberry/manager/__init__.py
+++ b/rlberry/manager/__init__.py
@@ -1,3 +1,3 @@
-from .agent_manager import AgentManager
+from .agent_manager import AgentManager, preset_manager
 from .multiple_managers import MultipleManagers
 from .evaluation import evaluate_agents, plot_writer_data, read_writer_data

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -1312,3 +1312,35 @@ def _strip_seed_dir(dico):
 def is_bz_file(filepath):
     with open(filepath, "rb") as test_f:
         return test_f.read(2) == b"BZ"
+
+
+def preset_manager(*args, **kwds):
+    """Preset an Agent Manager to some fixed keywords.
+
+    Examples
+    --------
+    >>> from rlberry.agents.torch import PPOAgent, DQNAgent
+    >>> from rlberry.manager import preset_manager
+    >>> from rlberry.envs import Acrobot
+    >>> env_ctor = Acrobot
+    >>> env_kwargs = {}
+    >>>
+    >>> manager_maker =  preset_manager(train_env=(env_ctor, env_kwargs),
+    >>>                                 eval_kwargs=dict(eval_horizon=500),
+    >>>                                 n_fit=4,
+    >>>                                 parallelization = "process",
+    >>>                                 mp_context="spawn",
+    >>>                                 seed=42,
+    >>>                                 max_workers=6
+    >>>                                 )
+    >>> ppo = manager_maker(PPOAgent, fit_budget = 100) # of type AgentManager
+    >>> dqn = manager_maker(DQNAgent, fit_budget = 200)
+    >>>
+    >>> ppo.fit()
+    >>> dqn.fit()
+    """
+
+    class Manager(AgentManager):
+        __init__ = functools.partialmethod(AgentManager.__init__, *args, **kwds)
+
+    return Manager

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -346,10 +346,10 @@ def test_preset():
 
     manager_maker = preset_manager(
         train_env=train_env,
-        fit_budget=2,
+        fit_budget=4,
         eval_kwargs=eval_kwargs,
         init_kwargs=params,
-        n_fit=2,
+        n_fit=4,
         seed=123,
         init_kwargs_per_instance=params_per_instance,
     )

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -4,7 +4,12 @@ import sys
 import os
 from rlberry.envs import GridWorld
 from rlberry.agents import AgentWithSimplePolicy
-from rlberry.manager import AgentManager, plot_writer_data, evaluate_agents
+from rlberry.manager import (
+    AgentManager,
+    plot_writer_data,
+    evaluate_agents,
+    preset_manager,
+)
 
 
 class DummyAgent(AgentWithSimplePolicy):
@@ -326,6 +331,30 @@ def test_profile():
     )
     stats_agent1.generate_profile(fname="profile.prof")
     assert os.path.getsize("profile.prof") > 100, "agent manager saved an empty profile"
+
+
+def test_preset():
+    # Define train and evaluation envs
+    train_env = (GridWorld, {})
+
+    # Parameters
+    params = dict(hyperparameter1=-1, hyperparameter2=100)
+    eval_kwargs = dict(eval_horizon=10)
+
+    # Run AgentManager
+    params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
+
+    manager_maker = preset_manager(
+        train_env=train_env,
+        fit_budget=2,
+        eval_kwargs=eval_kwargs,
+        init_kwargs=params,
+        n_fit=2,
+        seed=123,
+        init_kwargs_per_instance=params_per_instance,
+    )
+    manager = manager_maker(DummyAgent)
+    manager.fit()
 
 
 def test_compress():


### PR DESCRIPTION

## Description

Allow to preset parameters of an agent once at beginning of script.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
