### PR TITLE
Fix readthedocs install

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -22,3 +22,5 @@ python:
    install:
     - requirements: docs/requirements.txt
     - requirements: requirements.txt
+    - method: pip
+      path: .


### PR DESCRIPTION


<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
