### PR TITLE
Upgrade from python3.9 to python3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,9 +5,9 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
 
 <!-- The badges -->
 <p align="center">
+   <a href="https://pypi.org/project/rlberry/">
+      <img alt="Python Version" src="https://img.shields.io/badge/python-3.10-blue">
+   </a> 
    <a href="https://github.com/rlberry-py/rlberry/workflows/test/badge.svg">
       <img alt="pytest" src="https://github.com/rlberry-py/rlberry/workflows/test/badge.svg">
    </a>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <p align="center">
    <a href="https://pypi.org/project/rlberry/">
       <img alt="Python Version" src="https://img.shields.io/badge/python-3.10-blue">
-   </a> 
+   </a>
    <a href="https://github.com/rlberry-py/rlberry/workflows/test/badge.svg">
       <img alt="pytest" src="https://github.com/rlberry-py/rlberry/workflows/test/badge.svg">
    </a>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
   variables:
     NUMBA_DISABLE_JIT: "1"
 
@@ -84,8 +84,8 @@ jobs:
     vmImage: 'macOS-12'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0
@@ -119,8 +119,8 @@ jobs:
     vmImage: 'windows-2022'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0
@@ -156,8 +156,8 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
   variables:
     NUMBA_DISABLE_JIT: "1"
 
@@ -189,8 +189,8 @@ jobs:
     vmImage: 'macOS-12'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0
@@ -219,8 +219,8 @@ jobs:
     vmImage: 'windows-2022'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
 
   steps:
   - task: UsePythonVersion@0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,10 @@ Changelog
 
 Dev version
 -----------
+*PR #335*
+
+ * Upgrade from Python3.9 -> python3.10
+
 
 Version 0.5.0
 -------------

--- a/scripts/apptainer_for_tests/README.md
+++ b/scripts/apptainer_for_tests/README.md
@@ -1,0 +1,17 @@
+
+To test rlberry, you can use this script to create a container that install the latest version, run the tests, and send the result by email.
+(or you can check inside the .sh file to only get the part you need)
+
+:warning: **WARNING** :warning: : In both files, you have to update the paths and names
+
+## .def
+Scripts to build your apptainer. 
+2 scripts :
+- 1 with the "current" version of python (from ubuntu:last)
+- 1 with a specific version of python to choose
+
+## .sh
+Script to run your apptainer and send the report
+use chmod +x [name].sh to make it executable
+
+To run this script you need to install "mailutils" first (to send the report by email) 

--- a/scripts/apptainer_for_tests/README.md
+++ b/scripts/apptainer_for_tests/README.md
@@ -5,7 +5,7 @@ To test rlberry, you can use this script to create a container that install the 
 :warning: **WARNING** :warning: : In both files, you have to update the paths and names
 
 ## .def
-Scripts to build your apptainer. 
+Scripts to build your apptainer.
 2 scripts :
 - 1 with the "current" version of python (from ubuntu:last)
 - 1 with a specific version of python to choose
@@ -14,4 +14,4 @@ Scripts to build your apptainer.
 Script to run your apptainer and send the report
 use chmod +x [name].sh to make it executable
 
-To run this script you need to install "mailutils" first (to send the report by email) 
+To run this script you need to install "mailutils" first (to send the report by email)

--- a/scripts/apptainer_for_tests/monthly_test_base.sh
+++ b/scripts/apptainer_for_tests/monthly_test_base.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Set the email recipient and subject
+recipient="email1@inria.fr,email2@inria.fr"
+attachment="test_report.txt"
+
+# Build, then run, the Apptainer container and capture the test results
+cd [Path_to_your_apptainer_folder]
+#build the apptainer from the .def file  into an .sif image
+apptainer build --fakeroot --force rlberry_apptainer_base.sif rlberry_apptainer_base.def
+#Run the "runscript" section, and export the result inside a file (named previously)
+apptainer run --fakeroot --overlay my_overlay/ rlberry_apptainer.sif > "$attachment"
+
+
+# Send the test results by email
+exit_code=$(cat [path]/exit_code.txt)  # Read the exit code from the file
+
+if [ $exit_code -eq 0 ]; then
+    # Initialization when the exit code is 0 (success)
+    subject="Rlberry : Succes Monthly Test Report"
+    core_message="Success. Please find attached the monthly test report."
+else
+    # Initialization when the exit code is not 0 (failed)
+    subject="Rlberry : Failed Monthly Test Report"
+    core_message="Failed. Please find attached the monthly test report."
+fi
+
+echo "$core_message" | mail -s "$subject" -A "$attachment" "$recipient"  -aFrom:"Rlberry_Monthly_tests"
+

--- a/scripts/apptainer_for_tests/monthly_test_base.sh
+++ b/scripts/apptainer_for_tests/monthly_test_base.sh
@@ -26,4 +26,3 @@ else
 fi
 
 echo "$core_message" | mail -s "$subject" -A "$attachment" "$recipient"  -aFrom:"Rlberry_Monthly_tests"
-

--- a/scripts/apptainer_for_tests/rlberry_apptainer__specific_python.def
+++ b/scripts/apptainer_for_tests/rlberry_apptainer__specific_python.def
@@ -15,19 +15,19 @@ From: ubuntu:latest
     DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y python[version] python[version]-dev python[version]-venv python3-pip git ffmpeg libsm6 libxext6 libsdl2-dev xvfb x11-xkb-utils --no-install-recommends
     update-alternatives --install /usr/bin/python3 python3 /usr/bin/python[version] 1
     pip3 install --upgrade pip
-    
-     
+
+
     #Remove the old tmp folder if it exist, then install rlberry
-    if [ -d /tmp/rlberry_test_dir[version] ]; then /bin/rm -r /tmp/rlberry_test_dir[version]; fi 
+    if [ -d /tmp/rlberry_test_dir[version] ]; then /bin/rm -r /tmp/rlberry_test_dir[version]; fi
     git clone https://github.com/rlberry-py/rlberry.git /tmp/rlberry_test_dir[version]
 
     #Install all the lib we need to run rlberry and its tests
-    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages 
+    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages
     pip3 install gymnasium[other]
 
 #Environmment variable, Don't forget to change [version]
 %environment
-    export LC_ALL=C  
+    export LC_ALL=C
     export PATH="/usr/bin/python[version]:$PATH"
 
 #script that will be executed with the "run" command : run the tests in rlberry, then export the exit code inside a text file
@@ -35,4 +35,3 @@ From: ubuntu:latest
     cd /tmp/rlberry_test_dir[version] && \
     pytest rlberry
     echo $? > [path]/exit_code.txt
-

--- a/scripts/apptainer_for_tests/rlberry_apptainer__specific_python.def
+++ b/scripts/apptainer_for_tests/rlberry_apptainer__specific_python.def
@@ -1,0 +1,38 @@
+Bootstrap: docker
+From: ubuntu:latest
+
+#script for the build
+%post -c /bin/bash
+
+    #get the last Ubuntu Update, and add the desdsnakes ppa to acces other python version
+    apt-get update \
+    && apt-get upgrade -y
+    apt-get install -y software-properties-common
+    add-apt-repository ppa:deadsnakes/ppa -y
+    apt-get update
+
+    # Install python, and graphic and basic libs. Don't forget to change [version] by the python you want  (python[version] > python3.11), then set the new python as "main" python
+    DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install -y python[version] python[version]-dev python[version]-venv python3-pip git ffmpeg libsm6 libxext6 libsdl2-dev xvfb x11-xkb-utils --no-install-recommends
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python[version] 1
+    pip3 install --upgrade pip
+    
+     
+    #Remove the old tmp folder if it exist, then install rlberry
+    if [ -d /tmp/rlberry_test_dir[version] ]; then /bin/rm -r /tmp/rlberry_test_dir[version]; fi 
+    git clone https://github.com/rlberry-py/rlberry.git /tmp/rlberry_test_dir[version]
+
+    #Install all the lib we need to run rlberry and its tests
+    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages 
+    pip3 install gymnasium[other]
+
+#Environmment variable, Don't forget to change [version]
+%environment
+    export LC_ALL=C  
+    export PATH="/usr/bin/python[version]:$PATH"
+
+#script that will be executed with the "run" command : run the tests in rlberry, then export the exit code inside a text file
+%runscript
+    cd /tmp/rlberry_test_dir[version] && \
+    pytest rlberry
+    echo $? > [path]/exit_code.txt
+

--- a/scripts/apptainer_for_tests/rlberry_apptainer_base.def
+++ b/scripts/apptainer_for_tests/rlberry_apptainer_base.def
@@ -1,0 +1,36 @@
+Bootstrap: docker
+From: ubuntu:latest
+
+#script for the build
+%post -c /bin/bash
+
+    #get the last Ubuntu Update, 
+    apt-get update \
+    && apt-get upgrade -y
+    
+    # Install python, and graphic and basic libs.
+    apt-get install -y software-properties-common python3-pip git ffmpeg libsm6 libxext6 libsdl2-dev xvfb x11-xkb-utils 
+    
+    #Remove the old tmp folder if it exist, then download rlberry
+    if [ -d /tmp/rlberry_test_dir ]; then /bin/rm -r /tmp/rlberry_test_dir; fi 
+    git clone https://github.com/rlberry-py/rlberry.git /tmp/rlberry_test_dir
+
+    #Install all the lib we need to run rlberry and its tests
+    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages 
+    pip3 install gymnasium[other]
+
+%environment
+    export LC_ALL=C  
+
+#script that will be executed with the "run" command : run the tests in rlberry, the longtests, and then export the exit code inside a text file
+%runscript
+    pip list
+    cd /tmp/rlberry_test_dir && \
+    pytest rlberry && \
+    pytest long_tests/rl_agent/ltest_mbqvi_applegold.py long_tests/torch_agent/ltest_a2c_cartpole.py long_tests/torch_agent/ltest_ctn_ppo_a2c_pendulum.py long_tests/torch_agent/ltest_dqn_montaincar.py
+
+    echo $? > [path]/exit_code.txt
+
+    #Run all the long test
+    #pytest long_tests/**/*.py
+

--- a/scripts/apptainer_for_tests/rlberry_apptainer_base.def
+++ b/scripts/apptainer_for_tests/rlberry_apptainer_base.def
@@ -4,23 +4,23 @@ From: ubuntu:latest
 #script for the build
 %post -c /bin/bash
 
-    #get the last Ubuntu Update, 
+    #get the last Ubuntu Update,
     apt-get update \
     && apt-get upgrade -y
-    
+
     # Install python, and graphic and basic libs.
-    apt-get install -y software-properties-common python3-pip git ffmpeg libsm6 libxext6 libsdl2-dev xvfb x11-xkb-utils 
-    
+    apt-get install -y software-properties-common python3-pip git ffmpeg libsm6 libxext6 libsdl2-dev xvfb x11-xkb-utils
+
     #Remove the old tmp folder if it exist, then download rlberry
-    if [ -d /tmp/rlberry_test_dir ]; then /bin/rm -r /tmp/rlberry_test_dir; fi 
+    if [ -d /tmp/rlberry_test_dir ]; then /bin/rm -r /tmp/rlberry_test_dir; fi
     git clone https://github.com/rlberry-py/rlberry.git /tmp/rlberry_test_dir
 
     #Install all the lib we need to run rlberry and its tests
-    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages 
+    pip3 install rlberry[torch_agents] opencv-python pytest pytest-xvfb pytest-xprocess tensorboard #--break-system-packages
     pip3 install gymnasium[other]
 
 %environment
-    export LC_ALL=C  
+    export LC_ALL=C
 
 #script that will be executed with the "run" command : run the tests in rlberry, the longtests, and then export the exit code inside a text file
 %runscript
@@ -33,4 +33,3 @@ From: ubuntu:latest
 
     #Run all the long test
     #pytest long_tests/**/*.py
-

--- a/setup.py
+++ b/setup.py
@@ -85,7 +85,7 @@ setup(
         "Intended Audience :: Science/Research",
         "Intended Audience :: Education",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3 :: Only",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",


### PR DESCRIPTION
## Description
Update code, CI and doc  from python3.9 -> to python3.10

add scripts to run tests with python (3.9,3.10,and 3.11) in Apptainer (previously singularity) 

## Checklist
- \[ ] I have made corresponding changes to the documentation,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.

