### PR TITLE
Reverse order of lower and upper bounds arguments in bounded UCB/MOSS indices

### DIFF
--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -42,7 +42,7 @@ class BernoulliUCBAgent(IndexAgent):
     name = "Bernoulli UCB Agent"
 
     def __init__(self, env, **kwargs):
-        index, _ = makeBoundedUCBIndex(1, 0)
+        index, _ = makeBoundedUCBIndex(0, 1)
         IndexAgent.__init__(self, env, index, **kwargs)
         self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 

--- a/rlberry/agents/bandits/indices.py
+++ b/rlberry/agents/bandits/indices.py
@@ -81,8 +81,8 @@ def makeSubgaussianUCBIndex(
 
 
 def makeBoundedUCBIndex(
-    upper_bound: float = 1.0,
     lower_bound: float = 0.0,
+    upper_bound: float = 1.0,
     delta: Callable = lambda t: 1 / (1 + (t + 1) * np.log(t + 1) ** 2),
 ):
     """
@@ -92,11 +92,11 @@ def makeBoundedUCBIndex(
 
     Parameters
     ----------
-    upper_bound: float, default: 1.0
-        Upper bound on the rewards.
-
     lower_bound: float, default: 0.0
         Lower bound on the rewards.
+
+    upper_bound: float, default: 1.0
+        Upper bound on the rewards.
 
     delta: Callable,
         Confidence level. Default is tuned to have asymptotically optimal
@@ -167,7 +167,7 @@ def makeSubgaussianMOSSIndex(T: int = 1, A: int = 2, sigma: float = 1.0):
 
 
 def makeBoundedMOSSIndex(
-    T: float = 1, A: float = 2, upper_bound: float = 1.0, lower_bound: float = 0.0
+    T: float = 1, A: float = 2, lower_bound: float = 0.0, upper_bound: float = 1.0
 ):
     """
     MOSS index for bounded distributions, see Chapters 9 in [1].
@@ -182,11 +182,11 @@ def makeBoundedMOSSIndex(
     A: int
         Number of arms.
 
-    upper_bound: float, default: 1.0
-        Upper bound on the rewards.
-
     lower_bound: float, default: 0.0
         Lower bound on the rewards.
+
+    upper_bound: float, default: 1.0
+        Upper bound on the rewards.
 
     Return
     ------


### PR DESCRIPTION

## Description

A UCB index for rewards in [0,1] is now obtained by writing `makeBoundedUCBIndex(0, 1)`, instead of `makeBoundedUCBIndex(1, 0)`.

Closes #346 

## Checklist
- \[x] My code follows the style guideline
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[x] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.
