### PR TITLE
[WIP] Rename AgentManager to ExperimentManager

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,7 +15,7 @@ Main classes
   :template: class.rst
 
 
-    manager.AgentManager
+    manager.ExperimentManager
     manager.MultipleManagers
 
 Evaluation and plot

--- a/docs/basics/DeepRLTutorial/TutorialDeepRL.rst
+++ b/docs/basics/DeepRLTutorial/TutorialDeepRL.rst
@@ -15,7 +15,7 @@ Imports
 .. code:: python
 
     from rlberry.envs import gym_make
-    from rlberry.manager import plot_writer_data, AgentManager, evaluate_agents
+    from rlberry.manager import plot_writer_data, ExperimentManager, evaluate_agents
     from rlberry.agents.torch import A2CAgent
     from rlberry.agents.torch.utils.training import model_factory_from_env
 
@@ -149,9 +149,9 @@ default networks are:
 .. code:: python
 
     """
-    The AgentManager class is compact way of experimenting with a deepRL agent.
+    The ExperimentManager class is compact way of experimenting with a deepRL agent.
     """
-    default_agent = AgentManager(
+    default_agent = ExperimentManager(
         A2CAgent,  # The Agent class.
         (gym_make, dict(id="CartPole-v1")),  # The Environment to solve.
         fit_budget=3e5,  # The number of interactions
@@ -182,7 +182,7 @@ default networks are:
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for A2C default with n_fit = 1 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for A2C default with n_fit = 1 and max_workers = None.
     INFO: Making new env: CartPole-v1
     INFO: Making new env: CartPole-v1
     [INFO] Could not find least used device (nvidia-smi might be missing), use cuda:0 instead
@@ -353,7 +353,7 @@ and bigger batch size to have more stable training.
 
 .. code:: python
 
-    tuned_agent = AgentManager(
+    tuned_agent = ExperimentManager(
         A2CAgent,  # The Agent class.
         (gym_make, dict(id="CartPole-v1")),  # The Environment to solve.
         init_kwargs=dict(  # Where to put the agent's hyperparameters
@@ -399,7 +399,7 @@ and bigger batch size to have more stable training.
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for A2C tuned with n_fit = 1 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for A2C tuned with n_fit = 1 and max_workers = None.
     INFO: Making new env: CartPole-v1
     INFO: Making new env: CartPole-v1
     [INFO] Could not find least used device (nvidia-smi might be missing), use cuda:0 instead

--- a/docs/basics/compare_agents.rst
+++ b/docs/basics/compare_agents.rst
@@ -8,7 +8,7 @@ Compare different agents
 
 
 Two or more agents can be compared using the classes
-:class:`~rlberry.manager.agent_manager.AgentManager` and
+:class:`~rlberry.manager.agent_manager.ExperimentManager` and
 :class:`~rlberry.manager.multiple_managers.MultipleManagers`, as in the example below.
 
 
@@ -18,7 +18,7 @@ Two or more agents can be compared using the classes
         from rlberry.envs.classic_control import MountainCar
         from rlberry.agents.torch.reinforce import REINFORCEAgent
         from rlberry.agents.kernel_based.rs_kernel_ucbvi import RSKernelUCBVIAgent
-        from rlberry.manager import AgentManager, MultipleManagers, plot_writer_data
+        from rlberry.manager import ExperimentManager, MultipleManagers, plot_writer_data
 
 
         # Environment constructor and kwargs
@@ -38,10 +38,10 @@ Two or more agents can be compared using the classes
 
         eval_kwargs = dict(eval_horizon=200)
 
-        # Create AgentManager for REINFORCE and RSKernelUCBVI
+        # Create ExperimentManager for REINFORCE and RSKernelUCBVI
         multimanagers = MultipleManagers()
         multimanagers.append(
-            AgentManager(
+            ExperimentManager(
                 REINFORCEAgent,
                 env,
                 init_kwargs=params["reinforce"],
@@ -51,7 +51,7 @@ Two or more agents can be compared using the classes
             )
         )
         multimanagers.append(
-            AgentManager(
+            ExperimentManager(
                 RSKernelUCBVIAgent,
                 env,
                 init_kwargs=params["kernel"],

--- a/docs/basics/evaluate_agent.rst
+++ b/docs/basics/evaluate_agent.rst
@@ -9,14 +9,14 @@ Evaluate an agent and optimize its hyperparameters
 With rlberry_, once you created your agent, it is very easy to train in parallel
 several instances of it, analyze the results and optimize hyperparameters.
 
-This is one of the purposes of the :class:`~rlberry.manager.agent_manager.AgentManager` class,
+This is one of the purposes of the :class:`~rlberry.manager.agent_manager.ExperimentManager` class,
 as shown in the examples below.
 
 .. code-block:: python
 
     from rlberry.envs import gym_make
     from rlberry.agents.torch.reinforce import REINFORCEAgent
-    from rlberry.manager import AgentManager, plot_writer_data
+    from rlberry.manager import ExperimentManager, plot_writer_data
 
 
     # Environment (constructor, kwargs)
@@ -33,8 +33,8 @@ as shown in the examples below.
     eval_kwargs = dict(eval_horizon=500)  # parameters to evaluate the agent
 
 
-    # Create AgentManager to fit 4 instances of REINFORCE in parallel.
-    stats = AgentManager(
+    # Create ExperimentManager to fit 4 instances of REINFORCE in parallel.
+    stats = ExperimentManager(
         REINFORCEAgent,
         env,
         init_kwargs=params,
@@ -87,7 +87,7 @@ For :class:`~rlberry.agents.reinforce.reinforce.REINFORCEAgent`, this method loo
 
 
 Now we can use the :meth:`optimize_hyperparams` method
-of :class:`~rlberry.manager.agent_manager.AgentManager` to find good parameters for our agent:
+of :class:`~rlberry.manager.agent_manager.ExperimentManager` to find good parameters for our agent:
 
 .. code-block:: python
 

--- a/docs/basics/experiment_setup.rst
+++ b/docs/basics/experiment_setup.rst
@@ -13,7 +13,7 @@ To setup an experiment with rlberry, you can use yaml files. You'll need:
 
 * yaml files describing the environments and the agents
 
-* A main python script that reads the files and generates :class:`~rlberry.manager.agent_manager.AgentManager` instances to run each agent.
+* A main python script that reads the files and generates :class:`~rlberry.manager.agent_manager.ExperimentManager` instances to run each agent.
 
 
 This can be done very succinctly as in the example below:

--- a/docs/basics/multiprocess.rst
+++ b/docs/basics/multiprocess.rst
@@ -4,7 +4,7 @@ Parallelization in rlberry
 ==========================
 
 rlberry use python's standard multiprocessing library to execute the fit of agents in parallel on cpus. The parallelization is done via
-:class:`~rlberry.manager.AgentManager` and via :class:`~rlberry.manager.MultipleManagers`.
+:class:`~rlberry.manager.ExperimentManager` and via :class:`~rlberry.manager.MultipleManagers`.
 
 If a user wants to use a third-party parallelization library like joblib, the user must be aware of where the seeding is done so as not to bias the results. rlberry automatically handles seeding when the native parallelization scheme are used.
 
@@ -19,9 +19,9 @@ having practically no parallelization except if the code executed in each thread
 Process: spawn or forkserver
 ----------------------------
 
-To have an efficient parallelization, it is often better to use processes (see the doc on `python's website <https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing>`_) using the parameter :code:`parallelization="process"` in :class:`~rlberry.manager.AgentManager` or :class:`~rlberry.manager.MultipleManagers`.
+To have an efficient parallelization, it is often better to use processes (see the doc on `python's website <https://docs.python.org/3/library/multiprocessing.html#module-multiprocessing>`_) using the parameter :code:`parallelization="process"` in :class:`~rlberry.manager.ExperimentManager` or :class:`~rlberry.manager.MultipleManagers`.
 
-This implies that a new process will be launched for each fit of the AgentManager.
+This implies that a new process will be launched for each fit of the ExperimentManager.
 
 The advised method of parallelization is spawn (parameter :code:`mp_context="spawn"`), however spawn method has several drawbacks:
 
@@ -30,14 +30,14 @@ The advised method of parallelization is spawn (parameter :code:`mp_context="spa
 .. code:: python
 
     from rlberry.agents.torch import A2CAgent
-    from rlberry.manager import AgentManager
+    from rlberry.manager import ExperimentManager
     from rlberry.envs.benchmarks.ball_exploration import PBall2D
 
     n_steps = 1e5
     batch_size = 256
 
     if __name__ == "__main__":
-        manager = AgentManager(
+        manager = ExperimentManager(
             A2CAgent,
             (PBall2D, {}),
             init_kwargs=dict(batch_size=batch_size, gamma=0.99, learning_rate=0.001),

--- a/docs/basics/quick_start_rl/quickstart.rst
+++ b/docs/basics/quick_start_rl/quickstart.rst
@@ -26,7 +26,7 @@ Importing required libraries
     from rlberry.agents import UCBVIAgent, AgentWithSimplePolicy
     from rlberry.envs import Chain
     from rlberry.manager import (
-        AgentManager,
+        ExperimentManager,
         evaluate_agents,
         plot_writer_data,
         read_writer_data,
@@ -149,7 +149,7 @@ module :class:`~rlberry.agents.Agent` for more informations.
 Agent Manager
 -------------
 
-One of the main feature of rlberry is its :class:`~rlberry.manager.AgentManager`
+One of the main feature of rlberry is its :class:`~rlberry.manager.ExperimentManager`
 class. Here is a diagram to explain briefly what it does.
 
 
@@ -183,8 +183,8 @@ then spawn agents as desired during the experiment.
 
 .. code:: python
 
-    # Create AgentManager to fit 1 agent
-    ucbvi_stats = AgentManager(
+    # Create ExperimentManager to fit 1 agent
+    ucbvi_stats = ExperimentManager(
         UCBVIAgent,
         (env_ctor, env_kwargs),
         fit_budget=100,
@@ -194,8 +194,8 @@ then spawn agents as desired during the experiment.
     )
     ucbvi_stats.fit()
 
-    # Create AgentManager for baseline
-    baseline_stats = AgentManager(
+    # Create ExperimentManager for baseline
+    baseline_stats = ExperimentManager(
         RandomAgent,
         (env_ctor, env_kwargs),
         fit_budget=100,
@@ -207,9 +207,9 @@ then spawn agents as desired during the experiment.
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for UCBVI with n_fit = 1 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for UCBVI with n_fit = 1 and max_workers = None.
     [INFO] ... trained!
-    [INFO] Running AgentManager fit() for RandomAgent with n_fit = 1 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for RandomAgent with n_fit = 1 and max_workers = None.
     [INFO] ... trained!
 
 
@@ -307,8 +307,8 @@ Then, we fit the two agents and plot the data in the writer.
 
 .. code:: python
 
-    # Create AgentManager to fit 4 agents using 1 job
-    ucbvi_stats = AgentManager(
+    # Create ExperimentManager to fit 4 agents using 1 job
+    ucbvi_stats = ExperimentManager(
         UCBVIAgent2,
         (env_ctor, env_kwargs),
         fit_budget=50,
@@ -319,8 +319,8 @@ Then, we fit the two agents and plot the data in the writer.
     )  # mp_context is needed to have parallel computing in notebooks.
     ucbvi_stats.fit()
 
-    # Create AgentManager for baseline
-    baseline_stats = AgentManager(
+    # Create ExperimentManager for baseline
+    baseline_stats = ExperimentManager(
         RandomAgent2,
         (env_ctor, env_kwargs),
         fit_budget=5000,
@@ -330,8 +330,8 @@ Then, we fit the two agents and plot the data in the writer.
     )
     baseline_stats.fit()
 
-    # Create AgentManager for baseline
-    opti_stats = AgentManager(
+    # Create ExperimentManager for baseline
+    opti_stats = ExperimentManager(
         OptimalAgent,
         (env_ctor, env_kwargs),
         fit_budget=5000,
@@ -344,11 +344,11 @@ Then, we fit the two agents and plot the data in the writer.
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for UCBVIAgent2 with n_fit = 10 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for UCBVIAgent2 with n_fit = 10 and max_workers = None.
     [INFO] ... trained!
-    [INFO] Running AgentManager fit() for RandomAgent2 with n_fit = 10 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for RandomAgent2 with n_fit = 10 and max_workers = None.
     [INFO] ... trained!
-    [INFO] Running AgentManager fit() for OptimalAgent with n_fit = 10 and max_workers = None.
+    [INFO] Running ExperimentManager fit() for OptimalAgent with n_fit = 10 and max_workers = None.
     [INFO] ... trained!
 
 Remark that ``fit_budget`` may not mean the same thing among agents. For

--- a/docs/basics/rlberry how to.rst
+++ b/docs/basics/rlberry how to.rst
@@ -7,7 +7,7 @@ Libraries
     import pandas as pd
     from rlberry.agents import ValueIterationAgent, AgentWithSimplePolicy
     from rlberry.envs import GridWorld
-    from rlberry.manager import AgentManager, evaluate_agents
+    from rlberry.manager import ExperimentManager, evaluate_agents
 
 
 .. parsed-literal::
@@ -86,8 +86,8 @@ our estimation.
 
 .. code:: ipython3
 
-    # Create AgentManager to fit 4 agents using 1 job
-    vi_stats = AgentManager(
+    # Create ExperimentManager to fit 4 agents using 1 job
+    vi_stats = ExperimentManager(
         ValueIterationAgent,
         (env_ctor, env_kwargs),
         fit_budget=0,
@@ -96,8 +96,8 @@ our estimation.
         n_fit=1)
     vi_stats.fit()
 
-    # Create AgentManager for baseline
-    baseline_stats = AgentManager(
+    # Create ExperimentManager for baseline
+    baseline_stats = ExperimentManager(
         RandomAgent,
         (env_ctor, env_kwargs),
         fit_budget=0,
@@ -108,9 +108,9 @@ our estimation.
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for ValueIteration...
+    [INFO] Running ExperimentManager fit() for ValueIteration...
     [INFO] ... trained!
-    [INFO] Running AgentManager fit() for RandomAgent...
+    [INFO] Running ExperimentManager fit() for RandomAgent...
     [INFO] ... trained!
 
 
@@ -205,8 +205,8 @@ the variability of our estimation).
 
 .. code:: ipython3
 
-    # Create AgentManager to fit 4 agents using 1 job
-    vi_stats = AgentManager(
+    # Create ExperimentManager to fit 4 agents using 1 job
+    vi_stats = ExperimentManager(
         ValueIterationAgent2,
         (env_ctor, env_kwargs),
         fit_budget=1,
@@ -215,8 +215,8 @@ the variability of our estimation).
         n_fit=4)
     vi_stats.fit()
 
-    # Create AgentManager for baseline
-    baseline_stats = AgentManager(
+    # Create ExperimentManager for baseline
+    baseline_stats = ExperimentManager(
         RandomAgent2,
         (env_ctor, env_kwargs),
         fit_budget=1,
@@ -227,9 +227,9 @@ the variability of our estimation).
 
 .. parsed-literal::
 
-    [INFO] Running AgentManager fit() for ValueIterationAgent2...
+    [INFO] Running ExperimentManager fit() for ValueIterationAgent2...
     [INFO] ... trained!
-    [INFO] Running AgentManager fit() for RandomAgent2...
+    [INFO] Running ExperimentManager fit() for RandomAgent2...
     [INFO] ... trained!
 
 

--- a/docs/basics/seeding.rst
+++ b/docs/basics/seeding.rst
@@ -61,12 +61,12 @@ It works as follows:
 
 
 .. note::
-    The class :class:`~rlberry.manager.agent_manager.AgentManager` provides a :code:`seed` parameter in its constructor,
+    The class :class:`~rlberry.manager.agent_manager.ExperimentManager` provides a :code:`seed` parameter in its constructor,
     and handles automatically the seeding of all environments and agents used by it.
 
 .. note::
 
    The :meth:`optimize_hyperparams` method of
-   :class:`~rlberry.manager.agent_manager.AgentManager` uses the `Optuna <https://optuna.org/>`_
+   :class:`~rlberry.manager.agent_manager.ExperimentManager` uses the `Optuna <https://optuna.org/>`_
    library for hyperparameter optimization and is **inherently non-deterministic**
    (see `Optuna FAQ <https://optuna.readthedocs.io/en/stable/faq.html#how-can-i-obtain-reproducible-optimization-results>`_).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -95,7 +95,7 @@ Version 0.3.0
 
 *PR #191*
 
-* Possibility to generate a profile with :class:`rlberry.agents.manager.AgentManager`.
+* Possibility to generate a profile with :class:`rlberry.agents.manager.ExperimentManager`.
 
 *PR #148, #161, #180*
 
@@ -113,8 +113,8 @@ Version 0.3.0
 *Feb 22, 2022 (PR #126)*
 
 * Setup :code:`rlberry.__version__` (currently 0.3.0dev0)
-* Record rlberry version in a AgentManager attribute equality of AgentManagers
-* Override :code:`__eq__` method of the AgentManager class.
+* Record rlberry version in a ExperimentManager attribute equality of ExperimentManagers
+* Override :code:`__eq__` method of the ExperimentManager class.
 
 *Feb 14-15, 2022 (PR #97, #118)*
 
@@ -126,10 +126,10 @@ Version 0.3.0
 *Feb 11, 2022 (#83, #95)*
 
 * (fix) Fixed bug in :meth:`FiniteMDP.sample()`: terminal state was being checked with `self.state` instead of given `state`
-* (feat) Option to use 'fork' or 'spawn' in :class:`~rlberry.manager.AgentManager`
-* (feat) AgentManager output_dir now has a timestamp and a short ID by default.
+* (feat) Option to use 'fork' or 'spawn' in :class:`~rlberry.manager.ExperimentManager`
+* (feat) ExperimentManager output_dir now has a timestamp and a short ID by default.
 * (feat) Gridworld can be constructed from string layout
-* (feat) `max_workers` argument for :class:`~rlberry.manager.AgentManager` to control the maximum number of processes/threads created by the :meth:`fit` method.
+* (feat) `max_workers` argument for :class:`~rlberry.manager.ExperimentManager` to control the maximum number of processes/threads created by the :meth:`fit` method.
 
 
 *Feb 04, 2022*
@@ -145,12 +145,12 @@ Version 0.2.1
 -------------
 
 
-* :class:`~rlberry.agents.Agent` and :class:`~rlberry.manager.AgentManager` both have a unique_id attribute (useful for creating unique output files/directories).
+* :class:`~rlberry.agents.Agent` and :class:`~rlberry.manager.ExperimentManager` both have a unique_id attribute (useful for creating unique output files/directories).
 * `DefaultWriter` is now initialized in base class `Agent` and (optionally) wraps a tensorboard `SummaryWriter`.
-* :class:`~rlberry.manager.AgentManager` has an option enable_tensorboard that activates tensorboard logging in each of its Agents (with their writer attribute). The log_dirs of tensorboard are automatically assigned by :class:`~rlberry.manager.AgentManager`.
-* `RemoteAgentManager` receives tensorboard data created in the server, when the method `get_writer_data()` is called. This is done by a zip file transfer with :class:`~rlberry.network`.
+* :class:`~rlberry.manager.ExperimentManager` has an option enable_tensorboard that activates tensorboard logging in each of its Agents (with their writer attribute). The log_dirs of tensorboard are automatically assigned by :class:`~rlberry.manager.ExperimentManager`.
+* `RemoteExperimentManager` receives tensorboard data created in the server, when the method `get_writer_data()` is called. This is done by a zip file transfer with :class:`~rlberry.network`.
 * `BaseWrapper` and `gym_make` now have an option `wrap_spaces`. If set to `True`, this option converts `gym.spaces` to `rlberry.spaces`, which provides classes with better seeding (using numpy's default_rng instead of `RandomState`)
-* :class:`~rlberry.manager.AgentManager`: new method `get_agent_instances()` that returns trained instances
+* :class:`~rlberry.manager.ExperimentManager`: new method `get_agent_instances()` that returns trained instances
 * `plot_writer_data`: possibility to set `xtag` (tag used for x-axis)
 * Fixed agent initialization bug in `AgentHandler` (`eval_env` missing in `kwargs` for agent_class).
 
@@ -158,11 +158,11 @@ Version 0.2.1
 Version 0.2
 -----------
 
-* `AgentStats` renamed to :class:`~rlberry.manager.AgentManager`.
-* :class:`~rlberry.manager.AgentManager` can handle agents that cannot be pickled.
+* `AgentStats` renamed to :class:`~rlberry.manager.ExperimentManager`.
+* :class:`~rlberry.manager.ExperimentManager` can handle agents that cannot be pickled.
 * Agent interface requires `eval()` method instead of `policy()` to handle more general agents (e.g. reward-free, POMDPs etc).
 * Multi-processing and multi-threading are now done with `ProcessPoolExecutor` and `ThreadPoolExecutor` (allowing nested processes for example). Processes are created with spawn (jax does not work with fork, see #51).
 * JAX implementation of DQN and replay buffer using reverb (experimental).
 * :class:`~rlberry.network`: server and client interfaces to exchange messages via sockets (experimental).
-* `RemoteAgentManager` to train agents in a remote server and gather the results locally (experimental).
+* `RemoteExperimentManager` to train agents in a remote server and gather the results locally (experimental).
 * Fix rendering bug with OpenGL

--- a/docs/other/using_stable_baselines.rst
+++ b/docs/other/using_stable_baselines.rst
@@ -38,7 +38,7 @@ There are two important implementation details to note:
     model.
 
 The `Stable Baselines`_ algorithm class is a **required** parameter of the
-agent. In order to use it with AgentManagers, it must be included in the
+agent. In order to use it with ExperimentManagers, it must be included in the
 `init_kwargs` parameter. For example, below we use rlberry_ to train several instances of the A2C
 implementation of `Stable Baselines`_ and evaluate two hyperparameter configurations.
 
@@ -69,10 +69,10 @@ implementation of `Stable Baselines`_ and evaluate two hyperparameter configurat
 
 
     # Training several agents and comparing different hyperparams
-    from rlberry.manager import AgentManager, MultipleManagers, evaluate_agents
+    from rlberry.manager import ExperimentManager, MultipleManagers, evaluate_agents
 
     # Pass the wrapper directly with init_kwargs
-    stats = AgentManager(
+    stats = ExperimentManager(
         StableBaselinesAgent,
         (env_ctor, env_kwargs),
         agent_name="A2C baseline",
@@ -87,7 +87,7 @@ implementation of `Stable Baselines`_ and evaluate two hyperparameter configurat
     )
 
     # Pass a subclass for hyperparameter optimization
-    stats_alternative = AgentManager(
+    stats_alternative = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         agent_name="A2C optimized",

--- a/examples/demo_agents/demo_SAC.py
+++ b/examples/demo_agents/demo_SAC.py
@@ -13,7 +13,7 @@ during the fit of the agent.
 from rlberry.envs.basewrapper import Wrapper
 
 # from rlberry.envs import gym_make
-from rlberry.manager import plot_writer_data, AgentManager
+from rlberry.manager import plot_writer_data, ExperimentManager
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from rlberry.agents.experimental.torch import SACAgent
 import gymnasium as gym
@@ -27,7 +27,7 @@ def env_ctor(env, wrap_spaces=True):
 env = PBall2D()
 env = gym.wrappers.TimeLimit(env, max_episode_steps=100)
 env_kwargs = dict(env=env)
-agent = AgentManager(
+agent = ExperimentManager(
     SACAgent,
     (env_ctor, env_kwargs),
     fit_budget=500,
@@ -37,11 +37,11 @@ agent = AgentManager(
 
 # basic version
 # env_kwargs = dict(id = "CartPole-v1")
-# agent = AgentManager(SACAgent, (gym_make, env_kwargs), fit_budget=200, n_fit=1)
+# agent = ExperimentManager(SACAgent, (gym_make, env_kwargs), fit_budget=200, n_fit=1)
 
 # # timothe's
 # env = gym_make("CartPole-v1")
-# agent = AgentManager(
+# agent = ExperimentManager(
 #     SACAgent, (env.__class__, dict()), fit_budget=200, n_fit=1, enable_tensorboard=True,
 # )
 
@@ -50,7 +50,7 @@ agent = AgentManager(
 # from copy import deepcopy
 # def env_constructor():
 #     return deepcopy(env)
-# agent = AgentManager(
+# agent = ExperimentManager(
 #     SACAgent, (env_constructor, dict()), fit_budget=200, n_fit=1, enable_tensorboard=True,
 # )
 

--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -16,7 +16,7 @@ from rlberry.agents.bandits import (
     makeBetaPrior,
     makeGaussianPrior,
 )
-from rlberry.manager import AgentManager, plot_writer_data
+from rlberry.manager import ExperimentManager, plot_writer_data
 from rlberry.wrappers import WriterWrapper
 
 
@@ -59,7 +59,7 @@ env_ctor = BernoulliBandit
 env_kwargs = {"p": means}
 
 agents = [
-    AgentManager(
+    ExperimentManager(
         Agent,
         (env_ctor, env_kwargs),
         fit_budget=T,
@@ -125,7 +125,7 @@ env_ctor = NormalBandit
 env_kwargs = {"means": means, "stds": sigma * np.ones(A)}
 
 agents = [
-    AgentManager(
+    ExperimentManager(
         Agent,
         (env_ctor, env_kwargs),
         fit_budget=T,

--- a/examples/demo_bandits/plot_compare_index_bandits.py
+++ b/examples/demo_bandits/plot_compare_index_bandits.py
@@ -9,7 +9,7 @@ how to use subplots in with `plot_writer_data`
 import numpy as np
 import matplotlib.pyplot as plt
 from rlberry.envs.bandits import BernoulliBandit
-from rlberry.manager import AgentManager, plot_writer_data
+from rlberry.manager import ExperimentManager, plot_writer_data
 from rlberry.wrappers import WriterWrapper
 from rlberry.agents.bandits import (
     IndexAgent,
@@ -129,7 +129,7 @@ Agents_class = [
 ]
 
 agents = [
-    AgentManager(
+    ExperimentManager(
         Agent,
         (env_ctor, env_kwargs),
         fit_budget=T,

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -15,7 +15,7 @@ from rlberry.agents.bandits import (
     makeEXP3Index,
     makeBetaPrior,
 )
-from rlberry.manager import AgentManager, plot_writer_data
+from rlberry.manager import ExperimentManager, plot_writer_data
 from rlberry.wrappers import WriterWrapper
 
 
@@ -81,7 +81,7 @@ env_kwargs = {"rewards": rewards}
 Agents_class = [EXP3Agent, BernoulliTSAgent]
 
 agents = [
-    AgentManager(
+    ExperimentManager(
         Agent,
         (env_ctor, env_kwargs),
         init_kwargs={},

--- a/examples/demo_bandits/plot_mirror_bandit.py
+++ b/examples/demo_bandits/plot_mirror_bandit.py
@@ -14,7 +14,7 @@ and finally definition of the experiment.
 """
 import numpy as np
 
-from rlberry.manager import AgentManager, read_writer_data
+from rlberry.manager import ExperimentManager, read_writer_data
 from rlberry.envs.interface import Model
 from rlberry.agents.bandits import BanditWithSimplePolicy
 from rlberry.wrappers import WriterWrapper
@@ -158,7 +158,7 @@ class SeqHalvAgent(BanditWithSimplePolicy):
 
 # Experiment
 
-agent = AgentManager(
+agent = ExperimentManager(
     SeqHalvAgent,
     (env_ctor, env_kwargs),
     fit_budget=100,  # we use only 100 iterations for faster example run in doc.

--- a/examples/demo_bandits/plot_ucb_bandit.py
+++ b/examples/demo_bandits/plot_ucb_bandit.py
@@ -9,7 +9,7 @@ This script shows how to define a bandit environment and an UCB Index-based algo
 import numpy as np
 from rlberry.envs.bandits import NormalBandit
 from rlberry.agents.bandits import IndexAgent, makeSubgaussianUCBIndex
-from rlberry.manager import AgentManager, plot_writer_data
+from rlberry.manager import ExperimentManager, plot_writer_data
 import matplotlib.pyplot as plt
 from rlberry.wrappers import WriterWrapper
 
@@ -38,7 +38,7 @@ M = 20  # number of MC simu
 env_ctor = NormalBandit
 env_kwargs = {"means": means, "stds": 2 * np.ones(len(means))}
 
-agent = AgentManager(
+agent = ExperimentManager(
     UCBAgent,
     (env_ctor, env_kwargs),
     fit_budget=T,

--- a/examples/demo_env/example_atari_atlantis_vectorized_ppo.py
+++ b/examples/demo_env/example_atari_atlantis_vectorized_ppo.py
@@ -14,7 +14,7 @@ Agent is slightly tuned, but not optimal. This is just for illustration purpose.
 # sphinx_gallery_thumbnail_path = 'thumbnails/example_plot_atari_atlantis_vectorized_ppo.jpg'
 
 
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from datetime import datetime
 from rlberry.agents.torch import PPOAgent
 from gymnasium.wrappers.record_video import RecordVideo
@@ -67,7 +67,7 @@ critic_configs = {
 }
 
 
-tuned_agent = AgentManager(
+tuned_agent = ExperimentManager(
     PPOAgent,  # The Agent class.
     (
         atari_make,

--- a/examples/demo_env/example_atari_breakout_vectorized_ppo.py
+++ b/examples/demo_env/example_atari_breakout_vectorized_ppo.py
@@ -14,7 +14,7 @@ Agent is slightly tuned, but not optimal. This is just for illustration purpose.
 # sphinx_gallery_thumbnail_path = 'thumbnails/example_plot_atari_breakout_vectorized_ppo.jpg'
 
 
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from datetime import datetime
 from rlberry.agents.torch import PPOAgent
 from gymnasium.wrappers.record_video import RecordVideo
@@ -67,7 +67,7 @@ critic_configs = {
 }
 
 
-tuned_agent = AgentManager(
+tuned_agent = ExperimentManager(
     PPOAgent,  # The Agent class.
     (
         atari_make,

--- a/examples/demo_env/video_plot_atari_freeway.py
+++ b/examples/demo_env/video_plot_atari_freeway.py
@@ -14,7 +14,7 @@ Agent is slightly tuned, but not optimal. This is just for illustration purpose.
 # sphinx_gallery_thumbnail_path = 'thumbnails/video_plot_atari_freeway.jpg'
 
 
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from datetime import datetime
 from rlberry.agents.torch.dqn.dqn import DQNAgent
 from gymnasium.wrappers.record_video import RecordVideo
@@ -45,7 +45,7 @@ cnn_configs = {
     "is_policy": False,  # The network should output a distribution
 }
 
-tuned_agent = AgentManager(
+tuned_agent = ExperimentManager(
     DQNAgent,  # The Agent class.
     (
         atari_make,

--- a/examples/demo_network/run_client.py
+++ b/examples/demo_network/run_client.py
@@ -11,7 +11,7 @@ import numpy as np
 
 port = int(input("Select server port: "))
 client = BerryClient(port=port)
-# Send params for AgentManager
+# Send params for ExperimentManager
 client.send(
     Message.create(
         command=interface.Command.AGENT_MANAGER_CREATE_INSTANCE,

--- a/examples/demo_network/run_remote_manager.py
+++ b/examples/demo_network/run_remote_manager.py
@@ -9,9 +9,9 @@ from rlberry.network.interface import ResourceRequest
 
 from rlberry.agents.torch import REINFORCEAgent
 
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from rlberry.manager.multiple_managers import MultipleManagers
-from rlberry.manager.remote_agent_manager import RemoteAgentManager
+from rlberry.manager.remote_agent_manager import RemoteExperimentManager
 from rlberry.manager.evaluation import evaluate_agents, plot_writer_data
 
 
@@ -21,7 +21,7 @@ if __name__ == "__main__":
 
     FIT_BUDGET = 500
 
-    local_manager = AgentManager(
+    local_manager = ExperimentManager(
         agent_class=REINFORCEAgent,
         train_env=(gym_make, dict(id="CartPole-v1")),
         fit_budget=FIT_BUDGET,
@@ -33,7 +33,7 @@ if __name__ == "__main__":
         parallelization="process",
     )
 
-    remote_manager = RemoteAgentManager(
+    remote_manager = RemoteExperimentManager(
         client,
         agent_class=ResourceRequest(name="REINFORCEAgent"),
         train_env=ResourceRequest(name="gym_make", kwargs=dict(id="CartPole-v1")),
@@ -62,7 +62,7 @@ if __name__ == "__main__":
     # Test save/load
     fname1 = remote_manager.save()
     del remote_manager
-    remote_manager = RemoteAgentManager.load(fname1)
+    remote_manager = RemoteExperimentManager.load(fname1)
 
     # Fit everything in parallel
     mmanagers = MultipleManagers(parallelization="thread")

--- a/examples/plot_agent_manager.py
+++ b/examples/plot_agent_manager.py
@@ -98,13 +98,13 @@ class RandomAgent(AgentWithSimplePolicy):
         return self.env.action_space.sample()
 
 
-from rlberry.manager import AgentManager, evaluate_agents
+from rlberry.manager import ExperimentManager, evaluate_agents
 
 # Define parameters
 vi_params = {"gamma": 0.1, "epsilon": 1e-3}
 
-# Create AgentManager to fit 4 agents using 1 job
-vi_stats = AgentManager(
+# Create ExperimentManager to fit 4 agents using 1 job
+vi_stats = ExperimentManager(
     ValueIterationAgent,
     (env_ctor, env_kwargs),
     fit_budget=0,
@@ -114,8 +114,8 @@ vi_stats = AgentManager(
 )
 vi_stats.fit()
 
-# Create AgentManager for baseline
-baseline_stats = AgentManager(
+# Create ExperimentManager for baseline
+baseline_stats = ExperimentManager(
     RandomAgent,
     (env_ctor, env_kwargs),
     fit_budget=0,

--- a/examples/plot_checkpointing.py
+++ b/examples/plot_checkpointing.py
@@ -9,7 +9,7 @@ This is a minimal example of how to create checkpoints while training
 your agents, and how to restore from a previous checkpoint.
 """
 from rlberry.agents import Agent
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 from rlberry.manager import plot_writer_data
 
 
@@ -55,19 +55,19 @@ class MyAgent(Agent):
 
 
 if __name__ == "__main__":
-    manager = AgentManager(
+    manager = ExperimentManager(
         MyAgent,
         fit_budget=-1,
         n_fit=2,
         seed=123,
     )
     # Save manager **before** fit for several timesteps! So that we can see why checkpoints are useful:
-    # even if AgentManager is interrupted, it can be loaded and continue training
+    # even if ExperimentManager is interrupted, it can be loaded and continue training
     # from last checkpoint.
-    # But first, we need an initial call to AgentManager.fit() (for zero or a small number of timesteps),
-    # so that AgentManager can instantiate MyAgent and it can start checkpointing itself.
+    # But first, we need an initial call to ExperimentManager.fit() (for zero or a small number of timesteps),
+    # so that ExperimentManager can instantiate MyAgent and it can start checkpointing itself.
     # This is because the __init__ method of MyAgent is only executed
-    # after the first call to AgentManager.fit().
+    # after the first call to ExperimentManager.fit().
     manager.fit(0)
     manager_file = manager.save()
     print(f"\n Saved manager at {manager_file}.\n")
@@ -82,7 +82,7 @@ if __name__ == "__main__":
 
     # Load manager and continue training from last checkpoint
     print(f"\n Loading manager from {manager_file}.\n")
-    loaded_manager = AgentManager.load(manager_file)
+    loaded_manager = ExperimentManager.load(manager_file)
     # Fit for 500 more timesteps
     loaded_manager.fit(500)
 

--- a/examples/plot_writer_wrapper.py
+++ b/examples/plot_writer_wrapper.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from rlberry.wrappers import WriterWrapper
 from rlberry.envs import GridWorld
-from rlberry.manager import plot_writer_data, AgentManager
+from rlberry.manager import plot_writer_data, ExperimentManager
 from rlberry.agents import UCBVIAgent
 import matplotlib.pyplot as plt
 
@@ -53,7 +53,7 @@ env_kwargs = dict(
 )
 
 env = env_ctor(**env_kwargs)
-agent = AgentManager(VIAgent, (env_ctor, env_kwargs), fit_budget=10, n_fit=3)
+agent = ExperimentManager(VIAgent, (env_ctor, env_kwargs), fit_budget=10, n_fit=3)
 
 agent.fit(budget=10)
 # comment the line above if you only want to load data from rlberry_data.

--- a/long_tests/rl_agent/ltest_mbqvi_applegold.py
+++ b/long_tests/rl_agent/ltest_mbqvi_applegold.py
@@ -1,6 +1,6 @@
 from rlberry.envs.benchmarks.grid_exploration.apple_gold import AppleGold
 from rlberry.agents.mbqvi import MBQVIAgent
-from rlberry.manager import AgentManager, evaluate_agents
+from rlberry.manager import ExperimentManager, evaluate_agents
 import numpy as np
 
 params = {}
@@ -11,7 +11,7 @@ params["horizon"] = None
 
 # hyperparameters from https://github.com/DLR-RM/rl-baselines3-zoo
 def test_mbqvi_applegold():
-    rbagent = AgentManager(
+    rbagent = ExperimentManager(
         MBQVIAgent,
         (AppleGold, None),
         init_kwargs=params,

--- a/long_tests/torch_agent/ltest_a2c_cartpole.py
+++ b/long_tests/torch_agent/ltest_a2c_cartpole.py
@@ -1,6 +1,6 @@
 from rlberry.envs import gym_make
 from rlberry.agents.torch import A2CAgent
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 from rlberry.agents.torch.utils.training import model_factory_from_env
 import numpy as np
 
@@ -24,7 +24,7 @@ def test_a2c_cartpole():
     env_ctor = gym_make
     env_kwargs = dict(id="CartPole-v1")
 
-    rbagent = AgentManager(
+    rbagent = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         agent_name="A2CAgent",

--- a/long_tests/torch_agent/ltest_ctn_ppo_a2c_pendulum.py
+++ b/long_tests/torch_agent/ltest_ctn_ppo_a2c_pendulum.py
@@ -1,6 +1,6 @@
 from rlberry.envs import gym_make
 from rlberry.agents.torch import A2CAgent, PPOAgent
-from rlberry.manager import AgentManager, plot_writer_data, evaluate_agents
+from rlberry.manager import ExperimentManager, plot_writer_data, evaluate_agents
 import seaborn as sns
 import matplotlib.pyplot as plt
 
@@ -15,7 +15,7 @@ def test_a2c_vs_ppo_pendul():
     env_ctor = gym_make
     env_kwargs = dict(id="Pendulum-v1")
 
-    a2cagent = AgentManager(
+    a2cagent = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         agent_name="A2CAgent",
@@ -31,7 +31,7 @@ def test_a2c_vs_ppo_pendul():
         learning_rate=0.001,
         k_epochs=10,
     )
-    ppoagent = AgentManager(
+    ppoagent = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         init_kwargs=ppo_init_kwargs,

--- a/long_tests/torch_agent/ltest_dqn_montaincar.py
+++ b/long_tests/torch_agent/ltest_dqn_montaincar.py
@@ -1,6 +1,6 @@
 from rlberry.envs import gym_make
 from rlberry.agents.torch import DQNAgent
-from rlberry.manager import AgentManager, evaluate_agents
+from rlberry.manager import ExperimentManager, evaluate_agents
 import numpy as np
 
 model_configs = {
@@ -15,7 +15,7 @@ def test_dqn_montaincar():
     env_ctor = gym_make
     env_kwargs = dict(id="MountainCar-v0")
 
-    rbagent = AgentManager(
+    rbagent = ExperimentManager(
         DQNAgent,
         (env_ctor, env_kwargs),
         init_kwargs=dict(

--- a/long_tests/torch_agent/ltest_dqn_vs_mdqn_acrobot.py
+++ b/long_tests/torch_agent/ltest_dqn_vs_mdqn_acrobot.py
@@ -1,7 +1,7 @@
 from rlberry.envs import gym_make
 from rlberry.agents.torch import DQNAgent
 from rlberry.agents.torch import MunchausenDQNAgent as MDQNAgent
-from rlberry.manager import AgentManager, evaluate_agents, plot_writer_data
+from rlberry.manager import ExperimentManager, evaluate_agents, plot_writer_data
 import matplotlib.pyplot as plt
 import seaborn as sns
 
@@ -49,7 +49,7 @@ def test_dqn_vs_mdqn_acro():
         learning_starts=5_000,
     )
 
-    dqnagent = AgentManager(
+    dqnagent = ExperimentManager(
         DQNAgent,
         (env_ctor, env_kwargs),
         init_kwargs=dqn_init_kwargs,
@@ -60,7 +60,7 @@ def test_dqn_vs_mdqn_acro():
         # mp_context="fork",
     )
 
-    mdqnagent = AgentManager(
+    mdqnagent = ExperimentManager(
         MDQNAgent,
         (env_ctor, env_kwargs),
         init_kwargs=mdqn_init_kwargs,

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -43,12 +43,12 @@ class Agent(ABC):
         Directory that the agent can use to store data.
     _execution_metadata : ExecutionMetadata, optional
         Extra information about agent execution (e.g. about which is the process id where the agent is running).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _thread_shared_data : dict, optional
-        Used by :class:`~rlberry.manager.AgentManager` to share data across Agent
+        Used by :class:`~rlberry.manager.ExperimentManager` to share data across Agent
         instances created in different threads.
     **kwargs : dict
         Classes that implement this interface must send ``**kwargs``
@@ -435,10 +435,10 @@ class AgentWithSimplePolicy(Agent):
         Directory that the agent can use to store data.
     _execution_metadata : ExecutionMetadata, optional
         Extra information about agent execution (e.g. about which is the process id where the agent is running).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     **kwargs : dict
         Classes that implement this interface must send ``**kwargs``
         to :code:`AgentWithSimplePolicy.__init__()`.
@@ -547,12 +547,12 @@ class AgentTorch(Agent):
         Directory that the agent can use to store data.
     _execution_metadata : ExecutionMetadata, optional
         Extra information about agent execution (e.g. about which is the process id where the agent is running).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _thread_shared_data : dict, optional
-        Used by :class:`~rlberry.manager.AgentManager` to share data across Agent
+        Used by :class:`~rlberry.manager.ExperimentManager` to share data across Agent
         instances created in different threads.
     **kwargs : dict
         Classes that implement this interface must send ``**kwargs``

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -96,10 +96,10 @@ class StableBaselinesAgent(AgentWithSimplePolicy):
         Directory that the agent can use to store data.
     _execution_metadata : ExecutionMetadata, optional
         Extra information about agent execution (e.g. about which is the process id where the agent is running).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
     _default_writer_kwargs : dict, optional
         Parameters to initialize :class:`~rlberry.utils.writers.DefaultWriter` (attribute self.writer).
-        Used by :class:`~rlberry.manager.AgentManager`.
+        Used by :class:`~rlberry.manager.ExperimentManager`.
 
     Examples
     --------

--- a/rlberry/agents/torch/tests/test_a2c.py
+++ b/rlberry/agents/torch/tests/test_a2c.py
@@ -1,6 +1,6 @@
 from rlberry.envs import Wrapper
 from rlberry.agents.torch import A2CAgent
-from rlberry.manager import AgentManager, evaluate_agents
+from rlberry.manager import ExperimentManager, evaluate_agents
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from gymnasium import make
 
@@ -11,7 +11,7 @@ def test_a2c():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    a2crlberry_stats = AgentManager(
+    a2crlberry_stats = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(100),
@@ -30,7 +30,7 @@ def test_a2c():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    a2crlberry_stats = AgentManager(
+    a2crlberry_stats = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(100),
@@ -50,7 +50,7 @@ def test_a2c():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    a2crlberry_stats = AgentManager(
+    a2crlberry_stats = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(100),
@@ -68,7 +68,7 @@ def test_a2c():
     env_ctor = PBall2D
     env_kwargs = dict()
 
-    a2crlberry_stats = AgentManager(
+    a2crlberry_stats = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(100),
@@ -89,7 +89,7 @@ def test_a2c():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    a2crlberry_stats = AgentManager(
+    a2crlberry_stats = ExperimentManager(
         A2CAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(100),

--- a/rlberry/agents/torch/tests/test_dqn.py
+++ b/rlberry/agents/torch/tests/test_dqn.py
@@ -2,7 +2,7 @@ import pytest
 from rlberry.envs import gym_make
 from rlberry.agents.torch.dqn import DQNAgent
 from rlberry.agents.torch.utils.training import model_factory
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 import os
 import pathlib
 
@@ -89,7 +89,7 @@ def test_dqn_agent_manager_classic_env():
     with tempfile.TemporaryDirectory() as tmpdirname:
         saving_path = tmpdirname + "/agentmanager_test_dqn_classic_env"
 
-        test_agent_manager = AgentManager(
+        test_agent_manager = ExperimentManager(
             DQNAgent,  # The Agent class.
             (
                 gym_make,
@@ -124,7 +124,7 @@ def test_dqn_agent_manager_classic_env():
         # test the loading function
         test_load_env = gym_make("CartPole-v1")
         path_to_load = next(pathlib.Path(saving_path).glob("**/*.pickle"))
-        loaded_agent_manager = AgentManager.load(path_to_load)
+        loaded_agent_manager = ExperimentManager.load(path_to_load)
         assert loaded_agent_manager
 
         # test the agent

--- a/rlberry/agents/torch/tests/test_ppo.py
+++ b/rlberry/agents/torch/tests/test_ppo.py
@@ -10,7 +10,7 @@
 import pytest
 from rlberry.envs import Wrapper
 from rlberry.agents.torch import PPOAgent
-from rlberry.manager import AgentManager, evaluate_agents
+from rlberry.manager import ExperimentManager, evaluate_agents
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
 from gymnasium import make
 from rlberry.agents.torch.utils.training import model_factory_from_env
@@ -25,7 +25,7 @@ def test_ppo():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -45,7 +45,7 @@ def test_ppo():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -65,7 +65,7 @@ def test_ppo():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -82,7 +82,7 @@ def test_ppo():
 
     env_ctor = PBall2D
     env_kwargs = dict()
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -103,7 +103,7 @@ def test_ppo():
     env_ctor = Wrapper
     env_kwargs = dict(env=mdp)
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -133,7 +133,7 @@ def test_ppo():
     )
     pporlberry_stats.fit()
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -168,7 +168,7 @@ def test_ppo():
 
     env_ctor = PBall2D
     env_kwargs = dict()
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),
@@ -183,7 +183,7 @@ def test_ppo():
     output = evaluate_agents([pporlberry_stats], n_simulations=2, plot=False)
     pporlberry_stats.clear_output_dir()
 
-    pporlberry_stats = AgentManager(
+    pporlberry_stats = ExperimentManager(
         PPOAgent,
         (env_ctor, env_kwargs),
         fit_budget=int(132),

--- a/rlberry/agents/torch/tests/test_torch_atari.py
+++ b/rlberry/agents/torch/tests/test_torch_atari.py
@@ -1,8 +1,8 @@
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from rlberry.agents.torch.dqn.dqn import DQNAgent
 from rlberry.envs.gym_make import atari_make
 
-from rlberry.manager.agent_manager import AgentManager
+from rlberry.manager.agent_manager import ExperimentManager
 from rlberry.agents.torch import PPOAgent
 from rlberry.agents.torch.utils.training import model_factory_from_env
 import pathlib
@@ -33,7 +33,7 @@ def test_forward_dqn():
         "is_policy": False,  # The network should output a distribution
     }
 
-    tuned_agent = AgentManager(
+    tuned_agent = ExperimentManager(
         DQNAgent,  # The Agent class.
         (
             atari_make,
@@ -80,7 +80,7 @@ def test_forward_empty_input_dim():
         "is_policy": False,  # The network should output a distribution
     }
 
-    tuned_agent = AgentManager(
+    tuned_agent = ExperimentManager(
         DQNAgent,  # The Agent class.
         (
             atari_make,
@@ -239,7 +239,7 @@ def test_ppo_agent_manager_vectorized_atari_env(num_envs):
             "out_size": 1,
         }
 
-        test_agent_manager = AgentManager(
+        test_agent_manager = ExperimentManager(
             PPOAgent,  # The Agent class.
             (
                 atari_make,
@@ -275,7 +275,7 @@ def test_ppo_agent_manager_vectorized_atari_env(num_envs):
         test_load_env = atari_make("ALE/Atlantis-v5")
         test_load_env.reset()
         path_to_load = next(pathlib.Path(saving_path).glob("**/*.pickle"))
-        loaded_agent_manager = AgentManager.load(path_to_load)
+        loaded_agent_manager = ExperimentManager.load(path_to_load)
         assert loaded_agent_manager
 
         # test the agent

--- a/rlberry/envs/tests/test_gym_make.py
+++ b/rlberry/envs/tests/test_gym_make.py
@@ -22,7 +22,7 @@ def test_atari_make():
 
 
 def test_rendering_with_atari_make():
-    from rlberry.manager.agent_manager import AgentManager
+    from rlberry.manager.agent_manager import ExperimentManager
     from rlberry.agents.torch import PPOAgent
     from gymnasium.wrappers.record_video import RecordVideo
     import os
@@ -69,7 +69,7 @@ def test_rendering_with_atari_make():
             "out_size": 1,
         }
 
-        tuned_agent = AgentManager(
+        tuned_agent = ExperimentManager(
             PPOAgent,  # The Agent class.
             (
                 atari_make,

--- a/rlberry/experiment/generator.py
+++ b/rlberry/experiment/generator.py
@@ -6,17 +6,17 @@ Usage:
 
 Options:
     -h --help                Show this screen.
-    --enable_tensorboard     Enable tensorboard writer in AgentManager.
+    --enable_tensorboard     Enable tensorboard writer in ExperimentManager.
     --n_fit=<nf>             Number of times each agent is fit [default: 4].
     --output_dir=<dir>       Directory to save the results [default: results].
     --parallelization=<par>  Either 'thread' or 'process' [default: process].
-    --max_workers=<workers>  Number of workers used by AgentManager.fit. Set to -1 for the maximum value. [default: -1]
+    --max_workers=<workers>  Number of workers used by ExperimentManager.fit. Set to -1 for the maximum value. [default: -1]
 """
 
 from docopt import docopt
 from pathlib import Path
 from rlberry.experiment.yaml_utils import parse_experiment_config
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 from rlberry import check_packages
 
 import rlberry
@@ -26,7 +26,7 @@ logger = rlberry.logger
 
 def experiment_generator():
     """
-    Parse command line arguments and yields AgentManager instances.
+    Parse command line arguments and yields ExperimentManager instances.
     """
     args = docopt(__doc__)
     max_workers = int(args["--max_workers"])
@@ -47,4 +47,4 @@ def experiment_generator():
                     "Option --enable_tensorboard is not available: tensorboard is not installed."
                 )
 
-        yield AgentManager(**agent_manager_kwargs)
+        yield ExperimentManager(**agent_manager_kwargs)

--- a/rlberry/experiment/load_results.py
+++ b/rlberry/experiment/load_results.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 import pandas as pd
 
 
@@ -42,7 +42,7 @@ def load_experiment_results(output_dir, experiment_name):
 
         output_data['experiment_dirs'] = list of paths to experiment directory (output_dir/experiment_name)
         output_data['agent_list'] = list containing the names of the agents in the experiment
-        output_data['manager'][agent_name] = fitted AgentManager for agent_name
+        output_data['manager'][agent_name] = fitted ExperimentManager for agent_name
         output_data['dataframes'][agent_name] = dict of pandas data frames from the last run of the experiment
         output_data['data_dir'][agent_name] = directory from which the results were loaded
     """
@@ -91,13 +91,13 @@ def load_experiment_results(output_dir, experiment_name):
         # store data_dir
         output_data["data_dir"][agent_name] = data_dirs[agent_name]
 
-        # store AgentManager
+        # store ExperimentManager
         output_data["manager"][agent_name] = None
         fname = data_dirs[agent_name] / "manager_obj.pickle"
         try:
-            output_data["manager"][agent_name] = AgentManager.load(fname)
+            output_data["manager"][agent_name] = ExperimentManager.load(fname)
         except Exception:
-            logger.warning(f"Could not load AgentManager instance for {agent_name}.")
+            logger.warning(f"Could not load ExperimentManager instance for {agent_name}.")
         logger.info("... loaded " + str(fname))
 
         # store data frames

--- a/rlberry/experiment/tests/test_experiment_generator.py
+++ b/rlberry/experiment/tests/test_experiment_generator.py
@@ -38,6 +38,6 @@ def test_mock_args(monkeypatch):
         else:
             raise ValueError()
 
-    #  check that seeding is the same for each AgentManager instance
+    #  check that seeding is the same for each ExperimentManager instance
     for ii in range(1, len(random_numbers)):
         assert np.array_equal(random_numbers[ii - 1], random_numbers[ii])

--- a/rlberry/experiment/yaml_utils.py
+++ b/rlberry/experiment/yaml_utils.py
@@ -105,7 +105,7 @@ def parse_experiment_config(
     parallelization: str = "process",
 ) -> Generator[Tuple[int, dict], None, None]:
     """
-    Read .yaml files. set global seed and convert to AgentManager instances.
+    Read .yaml files. set global seed and convert to ExperimentManager instances.
 
     Exemple of experiment config:
 
@@ -128,18 +128,18 @@ def parse_experiment_config(
     n_fit : int
         Number of instances of each agent to fit
     max_workers : int or None
-        Maximum number of workers created in the fit() method of an instance of AgentManager.
+        Maximum number of workers created in the fit() method of an instance of ExperimentManager.
     output_base_dir : str
-        Directory where to save AgentManager results.
+        Directory where to save ExperimentManager results.
     parallelization : 'thread' or 'process', default : 'process'
-        Choose whether processes or threads are used in AgentManager parallelization.
+        Choose whether processes or threads are used in ExperimentManager parallelization.
 
     Returns
     -------
     seed: int
         global seed
     agent_manager_kwargs:
-        parameters to create an AgentManager instance.
+        parameters to create an ExperimentManager instance.
     """
     with path.open() as file:
         config = yaml.safe_load(file)
@@ -148,7 +148,7 @@ def parse_experiment_config(
         n_fit = n_fit
 
         for agent_path in config["agents"]:
-            # set seed before creating AgentManager
+            # set seed before creating ExperimentManager
             seed = config["seed"]
 
             agent_name = Path(agent_path).stem

--- a/rlberry/manager/__init__.py
+++ b/rlberry/manager/__init__.py
@@ -1,3 +1,3 @@
-from .agent_manager import AgentManager, preset_manager
+from .agent_manager import ExperimentManager, preset_manager
 from .multiple_managers import MultipleManagers
 from .evaluation import evaluate_agents, plot_writer_data, read_writer_data

--- a/rlberry/manager/agent_manager.py
+++ b/rlberry/manager/agent_manager.py
@@ -47,7 +47,7 @@ class AgentHandler:
     """
     Wraps an Agent so that it can be either loaded in memory
     or represented by a file storing the Agent data.
-    It is used by `class`:~rlberry.manager.AgentManager` to handle the fact that
+    It is used by `class`:~rlberry.manager.ExperimentManager` to handle the fact that
     not all agents can be pickled, when returning from the processes that
     train the agents.
 
@@ -157,7 +157,7 @@ class AgentHandler:
 #
 
 
-class AgentManager:
+class ExperimentManager:
     """
     Class to train, optimize hyperparameters, evaluate and gather
     statistics about an agent.
@@ -246,8 +246,8 @@ class AgentManager:
     --------
     >>> from rlberry.agents.torch import A2CAgent
     >>> from rlberry.envs import gym_make
-    >>> from rlberry.manager import AgentManager
-    >>> manager = AgentManager(
+    >>> from rlberry.manager import ExperimentManager
+    >>> manager = ExperimentManager(
     >>>      A2CAgent,
     >>>      (env_ctor, env_kwargs),
     >>>      fit_budget=100,
@@ -283,7 +283,7 @@ class AgentManager:
         thread_shared_data=None,
     ):
         # agent_class should only be None when the constructor is called
-        # by the class method AgentManager.load(), since the agent class
+        # by the class method ExperimentManager.load(), since the agent class
         # will be loaded.
 
         if agent_class is None:
@@ -299,11 +299,11 @@ class AgentManager:
         # Check train_env and eval_env
         assert isinstance(
             train_env, Tuple
-        ), "[AgentManager]train_env must be Tuple (constructor, kwargs)"
+        ), "[ExperimentManager]train_env must be Tuple (constructor, kwargs)"
         if eval_env is not None:
             assert isinstance(
                 eval_env, Tuple
-            ), "[AgentManager]train_env must be Tuple (constructor, kwargs)"
+            ), "[ExperimentManager]train_env must be Tuple (constructor, kwargs)"
 
         # check options
         assert outdir_id_style in [None, "unique", "timestamp"]
@@ -329,7 +329,7 @@ class AgentManager:
         if parallelization != "thread" and thread_shared_data is not None:
             logger.warning(
                 f"Using thread_shared_data and parallelization = {parallelization}"
-                " in AgentManager does *not* share data among Agent instances!"
+                " in ExperimentManager does *not* share data among Agent instances!"
                 " Each process will have its copy of thread_shared_data."
             )
 
@@ -357,7 +357,7 @@ class AgentManager:
             try:
                 self.fit_budget = self.fit_kwargs.pop("fit_budget")
             except KeyError:
-                raise ValueError("[AgentManager] fit_budget missing in __init__().")
+                raise ValueError("[ExperimentManager] fit_budget missing in __init__().")
         # extra params per instance
         if init_kwargs_per_instance is not None:
             assert len(init_kwargs_per_instance) == n_fit
@@ -407,7 +407,7 @@ class AgentManager:
         # if default_writer_kwargs:
         #     logger.warning(
         #         "(Re)defining the following DefaultWriter"
-        #         f" parameters in AgentManager: {list(default_writer_kwargs.keys())}"
+        #         f" parameters in ExperimentManager: {list(default_writer_kwargs.keys())}"
         #     )
         for ii in range(n_fit):
             self.agent_default_writer_kwargs[ii].update(default_writer_kwargs)
@@ -567,7 +567,7 @@ class AgentManager:
             agent = self.agent_handlers[agent_idx]
             if agent.is_empty():
                 logger.error(
-                    "Calling eval() in an AgentManager instance contaning an empty AgentHandler."
+                    "Calling eval() in an ExperimentManager instance contaning an empty AgentHandler."
                     " Returning []."
                 )
                 return []
@@ -604,7 +604,7 @@ class AgentManager:
 
         Note
         -----
-        Must be called right after creating an instance of AgentManager.
+        Must be called right after creating an instance of ExperimentManager.
 
         Parameters
         ----------
@@ -617,12 +617,12 @@ class AgentManager:
             kwargs for writer_fn
         idx : int
             Index of the agent to set the writer (0 <= idx < `n_fit`).
-            AgentManager fits `n_fit` agents, the writer of each one of them
+            ExperimentManager fits `n_fit` agents, the writer of each one of them
             needs to be set separetely.
         """
         assert (
             idx >= 0 and idx < self.n_fit
-        ), "Invalid index sent to AgentManager.set_writer()"
+        ), "Invalid index sent to ExperimentManager.set_writer()"
         writer_kwargs = writer_kwargs or {}
         self.writers[idx] = (writer_fn, writer_kwargs)
 
@@ -676,12 +676,12 @@ class AgentManager:
                 _check_not_importing_main()
             except RuntimeError as exc:
                 raise RuntimeError(
-                    """Warning: in AgentManager, if mp_context='spawn' and
+                    """Warning: in ExperimentManager, if mp_context='spawn' and
                         parallelization="process" then the script must be run
                         outside a notebook and protected by a  if __name__ == '__main__':
                         For example:
                             if __name__ == '__main__':
-                                agent = AgentManager(UCBVIAgent,(Chain, {}),
+                                agent = ExperimentManager(UCBVIAgent,(Chain, {}),
                                                 mp_context="spawn",
                                                 parallelization="process")
 
@@ -690,7 +690,7 @@ class AgentManager:
                 ) from exc
 
         logger.info(
-            f"Running AgentManager fit() for {self.agent_name}"
+            f"Running ExperimentManager fit() for {self.agent_name}"
             f" with n_fit = {self.n_fit} and max_workers = {self.max_workers}."
         )
         seeders = self.seeder.spawn(self.n_fit)
@@ -763,14 +763,14 @@ class AgentManager:
                 self.default_writer_data[ii] = agent.writer.data
 
     def save(self):
-        """Save AgentManager data to :attr:`~rlberry.manager.agent_manager.AgentManager.output_dir`.
+        """Save ExperimentManager data to :attr:`~rlberry.manager.agent_manager.ExperimentManager.output_dir`.
 
-        Saves object so that the data can be later loaded to recreate an AgentManager instance.
+        Saves object so that the data can be later loaded to recreate an ExperimentManager instance.
 
         Returns
         -------
         :class:`pathlib.Path`
-            Filename where the AgentManager object was saved.
+            Filename where the ExperimentManager object was saved.
         """
         # use self.output_dir
         output_dir = self.output_dir_
@@ -799,7 +799,7 @@ class AgentManager:
                     logger.warning("Could not save default_writer_data.")
 
         #
-        # Pickle AgentManager instance
+        # Pickle ExperimentManager instance
         #
 
         # clear agent handlers
@@ -813,22 +813,22 @@ class AgentManager:
         try:
             with filename.open("wb") as ff:
                 pickle.dump(self.__dict__, ff)
-            logger.info("Saved AgentManager({}) using pickle.".format(self.agent_name))
+            logger.info("Saved ExperimentManager({}) using pickle.".format(self.agent_name))
         except Exception:
             try:
                 with filename.open("wb") as ff:
                     dill.dump(self.__dict__, ff)
                 logger.info(
-                    "Saved AgentManager({}) using dill.".format(self.agent_name)
+                    "Saved ExperimentManager({}) using dill.".format(self.agent_name)
                 )
             except Exception as ex:
-                logger.warning("[AgentManager] Instance cannot be pickled: " + str(ex))
+                logger.warning("[ExperimentManager] Instance cannot be pickled: " + str(ex))
 
         return filename
 
     @classmethod
     def load(cls, filename):
-        """Loads an AgentManager instance from a file.
+        """Loads an ExperimentManager instance from a file.
 
         Parameters
         ----------
@@ -836,8 +836,8 @@ class AgentManager:
 
         Returns
         -------
-        :class:`rlberry.manager.AgentManager`
-            Loaded instance of AgentManager.
+        :class:`rlberry.manager.ExperimentManager`
+            Loaded instance of ExperimentManager.
         """
         filename = Path(filename).with_suffix(".pickle")
 
@@ -1244,8 +1244,8 @@ def _optuna_objective(
     #
     # fit and evaluate agents
     #
-    # Create AgentManager with hyperparams
-    params_stats = AgentManager(
+    # Create ExperimentManager with hyperparams
+    params_stats = ExperimentManager(
         agent_class,
         train_env,
         fit_budget,
@@ -1346,14 +1346,14 @@ def preset_manager(*args, **kwds):
     >>>                                 seed=42,
     >>>                                 max_workers=6
     >>>                                 )
-    >>> ppo = manager_maker(PPOAgent, fit_budget = 100) # of type AgentManager
+    >>> ppo = manager_maker(PPOAgent, fit_budget = 100) # of type ExperimentManager
     >>> dqn = manager_maker(DQNAgent, fit_budget = 200)
     >>>
     >>> ppo.fit()
     >>> dqn.fit()
     """
 
-    class Manager(AgentManager):
-        __init__ = functools.partialmethod(AgentManager.__init__, *args, **kwds)
+    class Manager(ExperimentManager):
+        __init__ = functools.partialmethod(ExperimentManager.__init__, *args, **kwds)
 
     return Manager

--- a/rlberry/manager/multiple_managers.py
+++ b/rlberry/manager/multiple_managers.py
@@ -13,12 +13,12 @@ def fit_stats(stats, save):
 
 class MultipleManagers:
     """
-    Class to fit multiple AgentManager instances in parallel with multiple threads.
+    Class to fit multiple ExperimentManager instances in parallel with multiple threads.
 
     Parameters
     ----------
     max_workers: int, default=None
-        max number of workers (AgentManager instances) fitted at the same time.
+        max number of workers (ExperimentManager instances) fitted at the same time.
     parallelization: {'thread', 'process'}, default: 'process'
         Whether to parallelize  agent training using threads or processes.
     mp_context: {'spawn', 'fork', 'forkserver'}, default: 'spawn'.
@@ -41,23 +41,23 @@ class MultipleManagers:
 
     def append(self, agent_manager):
         """
-        Append new AgentManager instance.
+        Append new ExperimentManager instance.
 
         Parameters
         ----------
-        agent_manager : AgentManager
+        agent_manager : ExperimentManager
         """
         self.instances.append(agent_manager)
 
     def run(self, save=True):
         """
-        Fit AgentManager instances in parallel.
+        Fit ExperimentManager instances in parallel.
 
         Parameters
         ----------
         save: bool, default: True
-            If true, save AgentManager intances immediately after fitting.
-            AgentManager.save() is called.
+            If true, save ExperimentManager intances immediately after fitting.
+            ExperimentManager.save() is called.
         """
         if self.parallelization == "thread":
             executor_class = concurrent.futures.ThreadPoolExecutor
@@ -84,8 +84,8 @@ class MultipleManagers:
 
     def save(self):
         """
-        Pickle AgentManager instances and saves fit statistics in .csv files.
-        The output folder is defined in each of the AgentManager instances.
+        Pickle ExperimentManager instances and saves fit statistics in .csv files.
+        The output folder is defined in each of the ExperimentManager instances.
         """
         for stats in self.instances:
             stats.save()

--- a/rlberry/manager/remote_agent_manager.py
+++ b/rlberry/manager/remote_agent_manager.py
@@ -16,16 +16,16 @@ import rlberry
 logger = rlberry.logger
 
 
-class RemoteAgentManager:
+class RemoteExperimentManager:
     """
-    Class to define a client that handles an AgentManager instance in a remote BerryServer.
+    Class to define a client that handles an ExperimentManager instance in a remote BerryServer.
 
     Parameters
     ----------
     client: BerryClient
         Client instance, to communicate with a BerryServer.
     **kwargs:
-        Parameters for AgentManager instance.
+        Parameters for ExperimentManager instance.
         Some parameters (as agent_class, train_env, eval_env) can be defined using a ResourceRequest.
     """
 
@@ -37,7 +37,7 @@ class RemoteAgentManager:
         if client:
             self._client = client
 
-            # Create a remote AgentManager object and keep reference to the filename
+            # Create a remote ExperimentManager object and keep reference to the filename
             # in the server where the object was saved.
             msg = self._client.send(
                 interface.Message.create(
@@ -64,8 +64,8 @@ class RemoteAgentManager:
 
     def get_writer_data(self):
         """
-        * Calls get_writer_data() in the remote AgentManager and returns the result locally.
-        * If tensorboard data is available in the remote AgentManager, the data is zipped,
+        * Calls get_writer_data() in the remote ExperimentManager and returns the result locally.
+        * If tensorboard data is available in the remote ExperimentManager, the data is zipped,
         received locally and unzipped.
         """
         msg = self._client.send(
@@ -174,11 +174,11 @@ class RemoteAgentManager:
 
     def save(self):
         """
-        Save RemoteAgentManager data to self.output_dir.
+        Save RemoteExperimentManager data to self.output_dir.
 
         Returns
         -------
-        filename where the AgentManager object was saved.
+        filename where the ExperimentManager object was saved.
         """
         # use self.output_dir
         output_dir = self.output_dir
@@ -194,18 +194,18 @@ class RemoteAgentManager:
             with filename.open("wb") as ff:
                 pickle.dump(self.__dict__, ff)
             logger.info(
-                "Saved RemoteAgentManager({}) using pickle.".format(self.agent_name)
+                "Saved RemoteExperimentManager({}) using pickle.".format(self.agent_name)
             )
         except Exception:
             try:
                 with filename.open("wb") as ff:
                     dill.dump(self.__dict__, ff)
                 logger.info(
-                    "Saved RemoteAgentManager({}) using dill.".format(self.agent_name)
+                    "Saved RemoteExperimentManager({}) using dill.".format(self.agent_name)
                 )
             except Exception as ex:
                 logger.warning(
-                    "[RemoteAgentManager] Instance cannot be pickled: " + str(ex)
+                    "[RemoteExperimentManager] Instance cannot be pickled: " + str(ex)
                 )
 
         return filename
@@ -218,11 +218,11 @@ class RemoteAgentManager:
         try:
             with filename.open("rb") as ff:
                 tmp_dict = pickle.load(ff)
-            logger.info("Loaded RemoteAgentManager using pickle.")
+            logger.info("Loaded RemoteExperimentManager using pickle.")
         except Exception:
             with filename.open("rb") as ff:
                 tmp_dict = dill.load(ff)
-            logger.info("Loaded RemoteAgentManager using dill.")
+            logger.info("Loaded RemoteExperimentManager using dill.")
 
         obj.__dict__.clear()
         obj.__dict__.update(tmp_dict)

--- a/rlberry/manager/tests/test_agent_manager.py
+++ b/rlberry/manager/tests/test_agent_manager.py
@@ -5,7 +5,7 @@ import os
 from rlberry.envs import GridWorld
 from rlberry.agents import AgentWithSimplePolicy
 from rlberry.manager import (
-    AgentManager,
+    ExperimentManager,
     plot_writer_data,
     evaluate_agents,
     preset_manager,
@@ -56,9 +56,9 @@ def test_agent_manager_1():
     agent.fit(10)
     agent.policy(None)
 
-    # Run AgentManager
+    # Run ExperimentManager
     params_per_instance = [dict(hyperparameter2=ii) for ii in range(2)]
-    stats_agent1 = AgentManager(
+    stats_agent1 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -68,7 +68,7 @@ def test_agent_manager_1():
         seed=123,
         init_kwargs_per_instance=params_per_instance,
     )
-    stats_agent2 = AgentManager(
+    stats_agent2 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -103,7 +103,7 @@ def test_agent_manager_1():
 
     # test saving/loading
     fname = stats_agent1.save()
-    loaded_stats = AgentManager.load(fname)
+    loaded_stats = ExperimentManager.load(fname)
     assert stats_agent1.unique_id == loaded_stats.unique_id
 
     # test hyperparameter optimization call
@@ -124,8 +124,8 @@ def test_agent_manager_2():
     params = {}
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
-    stats_agent1 = AgentManager(
+    # Run ExperimentManager
+    stats_agent1 = ExperimentManager(
         DummyAgent,
         train_env,
         eval_env=eval_env,
@@ -135,7 +135,7 @@ def test_agent_manager_2():
         n_fit=4,
         seed=123,
     )
-    stats_agent2 = AgentManager(
+    stats_agent2 = ExperimentManager(
         DummyAgent,
         train_env,
         eval_env=eval_env,
@@ -167,7 +167,7 @@ def test_agent_manager_2():
 
     # test saving/loading
     fname = stats_agent1.save()
-    loaded_stats = AgentManager.load(fname)
+    loaded_stats = ExperimentManager.load(fname)
     assert stats_agent1.unique_id == loaded_stats.unique_id
 
     # test hyperparemeter optimization
@@ -187,14 +187,14 @@ def test_agent_manager_partial_fit_and_tuple_env(train_env):
     train_env = (
         GridWorld,
         None,
-    )  # tuple (constructor, kwargs) must also work in AgentManager
+    )  # tuple (constructor, kwargs) must also work in ExperimentManager
 
     # Parameters
     params = {}
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
-    stats = AgentManager(
+    # Run ExperimentManager
+    stats = ExperimentManager(
         DummyAgent,
         train_env,
         init_kwargs=params,
@@ -203,7 +203,7 @@ def test_agent_manager_partial_fit_and_tuple_env(train_env):
         eval_kwargs=eval_kwargs,
         seed=123,
     )
-    stats2 = AgentManager(
+    stats2 = ExperimentManager(
         DummyAgent,
         train_env,
         init_kwargs=params,
@@ -246,9 +246,9 @@ def test_equality():
     params = dict(hyperparameter1=-1, hyperparameter2=100)
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
+    # Run ExperimentManager
     params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
-    stats_agent1 = AgentManager(
+    stats_agent1 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -259,7 +259,7 @@ def test_equality():
         init_kwargs_per_instance=params_per_instance,
     )
 
-    stats_agent2 = AgentManager(
+    stats_agent2 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -270,7 +270,7 @@ def test_equality():
         init_kwargs_per_instance=params_per_instance,
     )
 
-    stats_agent3 = AgentManager(
+    stats_agent3 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=42,
@@ -293,9 +293,9 @@ def test_version():
     params = dict(hyperparameter1=-1, hyperparameter2=100)
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
+    # Run ExperimentManager
     params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
-    stats_agent1 = AgentManager(
+    stats_agent1 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -317,9 +317,9 @@ def test_profile():
     params = dict(hyperparameter1=-1, hyperparameter2=100)
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
+    # Run ExperimentManager
     params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
-    stats_agent1 = AgentManager(
+    stats_agent1 = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,
@@ -341,7 +341,7 @@ def test_preset():
     params = dict(hyperparameter1=-1, hyperparameter2=100)
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
+    # Run ExperimentManager
     params_per_instance = [dict(hyperparameter2=ii) for ii in range(4)]
 
     manager_maker = preset_manager(
@@ -367,8 +367,8 @@ def test_compress():
     )
     eval_kwargs = dict(eval_horizon=10)
 
-    # Run AgentManager
-    stats = AgentManager(
+    # Run ExperimentManager
+    stats = ExperimentManager(
         DummyAgent,
         train_env,
         fit_budget=5,

--- a/rlberry/manager/tests/test_agent_manager_seeding.py
+++ b/rlberry/manager/tests/test_agent_manager_seeding.py
@@ -1,7 +1,7 @@
 from rlberry.envs.tests.test_env_seeding import get_env_trajectory, compare_trajectories
 from rlberry.envs import gym_make
 from rlberry.envs.classic_control import MountainCar
-from rlberry.manager import AgentManager, MultipleManagers
+from rlberry.manager import ExperimentManager, MultipleManagers
 from rlberry.agents.torch import A2CAgent
 import gymnasium as gym
 import pytest
@@ -19,10 +19,10 @@ import pytest
     ],
 )
 def test_agent_manager_and_multiple_managers_seeding(env, agent_class):
-    agent_manager = AgentManager(
+    agent_manager = ExperimentManager(
         agent_class, env, fit_budget=2, init_kwargs={}, n_fit=6, seed=3456
     )
-    agent_manager_test = AgentManager(
+    agent_manager_test = ExperimentManager(
         agent_class, env, fit_budget=2, init_kwargs={}, n_fit=6, seed=3456
     )
 

--- a/rlberry/manager/tests/test_hyperparam_optim.py
+++ b/rlberry/manager/tests/test_hyperparam_optim.py
@@ -1,7 +1,7 @@
 from rlberry.envs import GridWorld
 from rlberry.agents import AgentWithSimplePolicy
 from rlberry.agents.dynprog.value_iteration import ValueIterationAgent
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 from optuna.samplers import TPESampler
 import numpy as np
 import pytest
@@ -49,8 +49,8 @@ def test_hyperparam_optim_tpe():
     # Define trainenv
     train_env = (GridWorld, {})
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Run AgentManager
-        stats_agent = AgentManager(
+        # Run ExperimentManager
+        stats_agent = ExperimentManager(
             DummyAgent,
             train_env,
             fit_budget=1,
@@ -81,8 +81,8 @@ def test_hyperparam_optim_random(parallelization, custom_eval_function, fit_frac
     # Define train env
     train_env = (GridWorld, {})
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Run AgentManager
-        stats_agent = AgentManager(
+        # Run ExperimentManager
+        stats_agent = ExperimentManager(
             DummyAgent,
             train_env,
             init_kwargs={},
@@ -108,8 +108,8 @@ def test_hyperparam_optim_grid():
     # Define train env
     train_env = (GridWorld, {})
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Run AgentManager
-        stats_agent = AgentManager(
+        # Run ExperimentManager
+        stats_agent = ExperimentManager(
             DummyAgent,
             train_env,
             init_kwargs={},
@@ -132,8 +132,8 @@ def test_hyperparam_optim_cmaes():
     # Define train env
     train_env = (GridWorld, {})
     with tempfile.TemporaryDirectory() as tmpdirname:
-        # Run AgentManager
-        stats_agent = AgentManager(
+        # Run ExperimentManager
+        stats_agent = ExperimentManager(
             DummyAgent,
             train_env,
             init_kwargs={},
@@ -172,7 +172,7 @@ def test_discount_optimization():
 
     vi_params = {"gamma": 0.1, "epsilon": 1e-3}
 
-    vi_stats = AgentManager(
+    vi_stats = ExperimentManager(
         ValueIterationAgentToOptimize,
         env,
         fit_budget=0,

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -7,7 +7,7 @@ import sys
 
 from rlberry.wrappers import WriterWrapper
 from rlberry.envs import GridWorld
-from rlberry.manager import plot_writer_data, AgentManager, read_writer_data
+from rlberry.manager import plot_writer_data, ExperimentManager, read_writer_data
 from rlberry.agents import UCBVIAgent
 
 
@@ -23,7 +23,7 @@ def _create_and_fit_agent_manager(output_dir, outdir_id_style):
     env_ctor = GridWorld
     env_kwargs = dict(nrows=2, ncols=2, reward_at={(1, 1): 0.1, (2, 2): 1.0})
 
-    manager = AgentManager(
+    manager = ExperimentManager(
         VIAgent,
         (env_ctor, env_kwargs),
         fit_budget=10,

--- a/rlberry/manager/tests/test_shared_data.py
+++ b/rlberry/manager/tests/test_shared_data.py
@@ -1,7 +1,7 @@
 import pytest
 import numpy as np
 from rlberry.agents import Agent
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 
 
 class DummyAgent(Agent):
@@ -21,7 +21,7 @@ class DummyAgent(Agent):
 @pytest.mark.parametrize("paralellization", ["thread", "process"])
 def test_data_sharing(paralellization):
     shared_data = dict(X=np.arange(10))
-    manager = AgentManager(
+    manager = ExperimentManager(
         agent_class=DummyAgent,
         fit_budget=-1,
         n_fit=4,

--- a/rlberry/network/server_utils.py
+++ b/rlberry/network/server_utils.py
@@ -1,6 +1,6 @@
 import pathlib
 from rlberry.network import interface
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 from rlberry import metadata_utils
 import rlberry.utils.io
 import base64
@@ -24,7 +24,7 @@ def execute_message(
             params["output_dir"] = base_dir / "server_data" / params["output_dir"]
         else:
             params["output_dir"] = base_dir / "server_data/"
-        agent_manager = AgentManager(**params)
+        agent_manager = ExperimentManager(**params)
         filename = str(agent_manager.save())
         response = interface.Message.create(
             info=dict(
@@ -41,7 +41,7 @@ def execute_message(
         filename = message.params["filename"]
         budget = message.params["budget"]
         extra_params = message.params["extra_params"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         agent_manager.fit(budget, **extra_params)
         agent_manager.save()
         response = interface.Message.create(command=interface.Command.ECHO)
@@ -49,14 +49,14 @@ def execute_message(
     # AGENT_MANAGER_EVAL
     elif message.command == interface.Command.AGENT_MANAGER_EVAL:
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         eval_output = agent_manager.eval_agents(message.params["n_simulations"])
         response = interface.Message.create(data=dict(output=eval_output))
         del agent_manager
     # AGENT_MANAGER_CLEAR_OUTPUT_DIR
     elif message.command == interface.Command.AGENT_MANAGER_CLEAR_OUTPUT_DIR:
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         agent_manager.clear_output_dir()
         response = interface.Message.create(
             message=f"Cleared output dir: {agent_manager.output_dir}"
@@ -65,7 +65,7 @@ def execute_message(
     # AGENT_MANAGER_CLEAR_HANDLERS
     elif message.command == interface.Command.AGENT_MANAGER_CLEAR_HANDLERS:
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         agent_manager.clear_handlers()
         agent_manager.save()
         response = interface.Message.create(message=f"Cleared handlers: {filename}")
@@ -73,14 +73,14 @@ def execute_message(
     # AGENT_MANAGER_SET_WRITER
     elif message.command == interface.Command.AGENT_MANAGER_SET_WRITER:
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         agent_manager.set_writer(**message.params["kwargs"])
         agent_manager.save()
         del agent_manager
     # AGENT_MANAGER_OPTIMIZE_HYPERPARAMS
     elif message.command == interface.Command.AGENT_MANAGER_OPTIMIZE_HYPERPARAMS:
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         best_params_dict = agent_manager.optimize_hyperparams(
             **message.params["kwargs"]
         )
@@ -91,7 +91,7 @@ def execute_message(
     elif message.command == interface.Command.AGENT_MANAGER_GET_WRITER_DATA:
         # writer scalar data
         filename = message.params["filename"]
-        agent_manager = AgentManager.load(filename)
+        agent_manager = ExperimentManager.load(filename)
         writer_data = agent_manager.get_writer_data()
         writer_data = writer_data or dict()
         for idx in writer_data:

--- a/rlberry/network/tests/test_server.py
+++ b/rlberry/network/tests/test_server.py
@@ -8,7 +8,7 @@ import numpy as np
 from rlberry.network.client import BerryClient
 from rlberry.network import interface
 from rlberry.network.interface import Message, ResourceRequest
-from rlberry.manager.remote_agent_manager import RemoteAgentManager
+from rlberry.manager.remote_agent_manager import RemoteExperimentManager
 from rlberry.manager.evaluation import evaluate_agents
 
 server_name = "berry"
@@ -31,7 +31,7 @@ def start_server(xprocess):
 def test_client():
     port = 4242
     client = BerryClient(port=port)
-    # Send params for AgentManager
+    # Send params for ExperimentManager
     client.send(
         Message.create(
             command=interface.Command.AGENT_MANAGER_CREATE_INSTANCE,
@@ -64,7 +64,7 @@ def test_client():
 def test_remote_manager():
     port = 4242
     client = BerryClient(port=port)
-    remote_manager = RemoteAgentManager(
+    remote_manager = RemoteExperimentManager(
         client,
         agent_class=ResourceRequest(name="REINFORCEAgent"),
         train_env=ResourceRequest(name="gym_make", kwargs=dict(id="CartPole-v1")),
@@ -86,6 +86,6 @@ def test_remote_manager():
 
     fname1 = remote_manager.save()
     del remote_manager
-    remote_manager = RemoteAgentManager.load(fname1)
+    remote_manager = RemoteExperimentManager.load(fname1)
     remote_manager.fit(3)
     evaluate_agents([remote_manager], n_simulations=2, show=False)

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -1,6 +1,6 @@
 from rlberry.envs import Chain
 from rlberry.envs.benchmarks.ball_exploration import PBall2D
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 import numpy as np
 from rlberry.seeding import set_external_seed
 import tempfile
@@ -40,7 +40,7 @@ def _make_tuple_env(env):
 
 def _fit_agent_manager(agent, env="continuous_state", init_kwargs=None):
     """
-    Check that the agent is compatible with :class:`~rlberry.manager.AgentManager`.
+    Check that the agent is compatible with :class:`~rlberry.manager.ExperimentManager`.
 
     Parameters
     ----------
@@ -57,7 +57,7 @@ def _fit_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
     train_env = _make_tuple_env(env)
     try:
-        agent = AgentManager(
+        agent = ExperimentManager(
             agent, train_env, fit_budget=5, n_fit=1, seed=SEED, init_kwargs=init_kwargs
         )
         agent.fit()
@@ -98,7 +98,7 @@ def _fit_agent(agent, env="continuous_state", init_kwargs=None):
 
 def check_agent_manager(agent, env="continuous_state", init_kwargs=None):
     """
-    Check that the agent is compatible with :class:`~rlberry.manager.AgentManager`.
+    Check that the agent is compatible with :class:`~rlberry.manager.ExperimentManager`.
 
     Parameters
     ----------
@@ -116,7 +116,7 @@ def check_agent_manager(agent, env="continuous_state", init_kwargs=None):
 
 def check_agent_base(agent, env="continuous_state", init_kwargs=None):
     """
-    Check that the agent is compatible with :class:`~rlberry.manager.AgentManager`.
+    Check that the agent is compatible with :class:`~rlberry.manager.ExperimentManager`.
 
     Parameters
     ----------
@@ -239,7 +239,7 @@ def _check_save_load_with_manager(agent, env="continuous_state", init_kwargs=Non
 
     train_env_tuple = _make_tuple_env(env)
     with tempfile.TemporaryDirectory() as tmpdirname:
-        manager = AgentManager(
+        manager = ExperimentManager(
             agent,
             train_env_tuple,
             fit_budget=5,
@@ -276,7 +276,7 @@ def _check_save_load_with_manager(agent, env="continuous_state", init_kwargs=Non
         assert os.path.exists(tmpdirname)
 
         path_to_load = next(pathlib.Path(tmpdirname).glob("**/manager_obj.pickle"))
-        loaded_agent_manager = AgentManager.load(path_to_load)
+        loaded_agent_manager = ExperimentManager.load(path_to_load)
         assert loaded_agent_manager
 
         # test with first agent of the manager
@@ -562,8 +562,8 @@ def _test_hyperparam_optim_tpe(agent, env="continuous_state", init_kwargs=None):
     init_kwargs["seeder"] = SEED
     train_env = _make_tuple_env(env)
 
-    # Run AgentManager
-    stats_agent = AgentManager(
+    # Run ExperimentManager
+    stats_agent = ExperimentManager(
         agent,
         train_env,
         fit_budget=1,
@@ -586,8 +586,8 @@ def _test_hyperparam_optim_grid(agent, env="continuous_state", init_kwargs=None)
     init_kwargs["seeder"] = SEED
     train_env = _make_tuple_env(env)
 
-    # Run AgentManager
-    stats_agent = AgentManager(
+    # Run ExperimentManager
+    stats_agent = ExperimentManager(
         agent,
         train_env,
         init_kwargs={},
@@ -612,8 +612,8 @@ def _test_hyperparam_optim_cmaes(agent, env="continuous_state", init_kwargs=None
     init_kwargs["seeder"] = SEED
     train_env = _make_tuple_env(env)
 
-    # Run AgentManager
-    stats_agent = AgentManager(
+    # Run ExperimentManager
+    stats_agent = ExperimentManager(
         agent,
         train_env,
         init_kwargs={},
@@ -636,7 +636,7 @@ def _test_discount_optimization(agent, env="continuous_state", init_kwargs=None)
 
     vi_params = {"gamma": 0.1, "epsilon": 1e-3}
 
-    vi_stats = AgentManager(
+    vi_stats = ExperimentManager(
         agent,
         train_env,
         fit_budget=0,
@@ -668,8 +668,8 @@ def _test_hyperparam_optim_random(
     init_kwargs["seeder"] = SEED
     train_env = _make_tuple_env(env)
 
-    # Run AgentManager
-    stats_agent = AgentManager(
+    # Run ExperimentManager
+    stats_agent = ExperimentManager(
         agent,
         train_env,
         init_kwargs={},

--- a/rlberry/utils/check_bandit_agent.py
+++ b/rlberry/utils/check_bandit_agent.py
@@ -1,5 +1,5 @@
 from rlberry.envs.bandits import BernoulliBandit
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 
 
 def check_bandit_agent(Agent, environment=BernoulliBandit, seed=42):
@@ -40,10 +40,10 @@ def check_bandit_agent(Agent, environment=BernoulliBandit, seed=42):
     env_ctor = environment
     env_kwargs = {}
 
-    agent1 = AgentManager(
+    agent1 = ExperimentManager(
         Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=seed
     )
-    agent2 = AgentManager(
+    agent2 = ExperimentManager(
         Agent, (env_ctor, env_kwargs), fit_budget=10, n_fit=1, seed=seed
     )
 

--- a/rlberry/utils/tests/test_writer.py
+++ b/rlberry/utils/tests/test_writer.py
@@ -1,7 +1,7 @@
 import time
 from rlberry.envs import GridWorld
 from rlberry.agents import AgentWithSimplePolicy
-from rlberry.manager import AgentManager
+from rlberry.manager import ExperimentManager
 
 
 class DummyAgent(AgentWithSimplePolicy):
@@ -33,7 +33,7 @@ def test_myoutput(capsys):  # or use "capfd" for fd-level
     env_kwargs = dict()
 
     env = env_ctor(**env_kwargs)
-    agent = AgentManager(
+    agent = ExperimentManager(
         DummyAgent,
         (env_ctor, env_kwargs),
         fit_budget=3,

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -24,7 +24,7 @@ class DefaultWriter:
     Default writer to be used by the agents, optionally wraps an instance of tensorboard.SummaryWriter.
 
     Can be used in the fit() method of the agents, so
-    that training data can be handled by AgentManager and RemoteAgentManager.
+    that training data can be handled by ExperimentManager and RemoteExperimentManager.
 
     Parameters
     ----------


### PR DESCRIPTION

## Description

Rename AgentManager to ExperimentManager everywhere.
TODO: add an alias to keep the old name for backwards compatibility.

## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
