### PR TITLE
force sphinx version <7 (before the error)

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+sphinx<7
 sphinx-gallery
 sphinx-math-dollar
 numpydoc


### PR DESCRIPTION

## Description
Since there is an error with the last version of sphinx, we want to fix its version <7

similar issue here : https://github.com/readthedocs/readthedocs.org/issues/10279

```
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1127, in handle_page
    output = self.templates.render(templatename, ctx)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/readthedocs_ext/readthedocs.py", line 181, in rtd_render
    content = old_render(template, render_context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/jinja2glue.py", line 200, in render
    return self.environment.get_template(template).render(context)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/jinja2/environment.py", line 1301, in render
    self.environment.handle_exception()
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/jinja2/environment.py", line 936, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/themes/basic/page.html", line 10, in top-level template code
    {%- extends "layout.html" %}
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/checkouts/355/docs/themes/scikit-learn-fork/layout.html", line 36, in top-level template code
    <link rel="stylesheet" href="{{ pathto('_static/' + style, 1) }}" type="text/css" />
jinja2.exceptions.UndefinedError: 'style' is undefined

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/cmd/build.py", line 298, in build_main
    app.build(args.force_all, args.filenames)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/application.py", line 355, in build
    self.builder.build_update()
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 293, in build_update
    self.build(to_build,
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 363, in build
    self.write(docnames, list(updated_docnames), method)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 571, in write
    self._write_serial(sorted(docnames))
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/__init__.py", line 581, in _write_serial
    self.write_doc(docname, doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 655, in write_doc
    self.handle_page(docname, ctx, event_arg=doctree)
  File "/home/docs/checkouts/readthedocs.org/user_builds/rlberry/envs/355/lib/python3.10/site-packages/sphinx/builders/html/__init__.py", line 1134, in handle_page
    raise ThemeError(__("An error happened in rendering the page %s.\nReason: %r") %
sphinx.errors.ThemeError: An error happened in rendering the page about.
Reason: UndefinedError("'style' is undefined")

Theme error:
An error happened in rendering the page about.
Reason: UndefinedError("'style' is undefined")
```


## Checklist
- \[ ] My code follows the style guideline
To check :
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.

