### PR TITLE
Set version for seaborn

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ that you can spend most of your time developing agents.
 Install the latest version for a stable release.
 
 ```bash
-pip install -U git+https://github.com/rlberry-py/rlberry.git@v0.3.0#egg=rlberry[default]
+pip install rlberry
 ```
 
 The documentation includes more [installation instructions](https://rlberry.readthedocs.io/en/latest/installation.html) in particular for users that work with Jax.

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ that you can spend most of your time developing agents.
 Install the latest version for a stable release.
 
 ```bash
-pip install rlberry
+pip install -U git+https://github.com/rlberry-py/rlberry.git@v0.3.0#egg=rlberry[default]
 ```
 
 The documentation includes more [installation instructions](https://rlberry.readthedocs.io/en/latest/installation.html) in particular for users that work with Jax.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,7 +63,6 @@ Version 0.4.1
 Version 0.4.0
 -------------
 
-
 *PR #273*
 
 * Change the default behavior of `plot_writer_data` so that if seaborn has version >= 0.12.0 then

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ numpy>=1.17
 scipy>=1.6
 pygame-ce
 matplotlib
-seaborn
+seaborn==0.12.2
 pandas
 gymnasium[atari,accept-rom-license]
 dill


### PR DESCRIPTION
This freeze seaborn version to 0.12.2 in order to avoid the Nonetype non iterable error we have been having.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
