### PR TITLE
[FIX] fix seed in comparison of agents

### DIFF
--- a/.github/workflows/doc_stable.yml
+++ b/.github/workflows/doc_stable.yml
@@ -2,9 +2,8 @@ name: documentation_stable
 on:
   push:
     # Pattern matched against refs/tags
-    tags:        
+    tags:
       - '*'           # Push events to every tag not containing /
-
 
 permissions:
   contents: write

--- a/rlberry/manager/comparison.py
+++ b/rlberry/manager/comparison.py
@@ -19,7 +19,7 @@ def compare_agents(
     n_simulations=50,
     alpha=0.05,
     B=10_000,
-    seed=None
+    seed=None,
 ):
     """
     Compare several trained agents using the mean over n_simulations evaluations for each agent.
@@ -57,7 +57,7 @@ def compare_agents(
     [2]: Testing Statistical Hypotheses by E. L. Lehmann, Joseph P. Romano (Section 15.4.4), https://doi.org/10.1007/0-387-27605-X, Springer
 
     """
-        
+
     # Construction of the array of evaluations
     df = pd.DataFrame()
     assert isinstance(agent_source, list)
@@ -161,7 +161,7 @@ def compare_agents(
             }
         )
     elif method == "permutation":
-        results_perm = _permutation_test(data, B, alpha,seed) == 1
+        results_perm = _permutation_test(data, B, alpha, seed) == 1
         decisions = [
             "accept" if results_perm[i][j] else "reject"
             for i in range(n_agents)

--- a/rlberry/manager/tests/test_comparisons.py
+++ b/rlberry/manager/tests/test_comparisons.py
@@ -62,7 +62,7 @@ def test_compare(method):
     agent1.fit()
     agent2.fit()
 
-    df = compare_agents([agent1, agent2], method=method, B=10, n_simulations=5)
+    df = compare_agents([agent1, agent2], method=method, B=20, n_simulations=5, seed=42)
     assert len(df) > 0
     if method == "tukey_hsd":
         assert df["p-val"].item() < 0.05
@@ -74,6 +74,3 @@ def test_compare(method):
         [agent1_pickle, agent2_pickle], method=method, B=10, n_simulations=5
     )
     assert len(df) > 0
-
-
-test_compare("tukey_hsd")


### PR DESCRIPTION
Add a way to fix the seed in the hypothesis testing comparison of agent and fix the seed in the tests.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
