### PR TITLE
automatic save in ExperienceManager

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Dev version
 -----------
 
+
+*PR #397*
+
+ * Automatic save after fit() in ExperienceManager
+
 *PR #376*
 
  * New plot_writer_data function that does not depend on seaborn and that can plot smoothed function and confidence band if scikit-fda is installed.

--- a/rlberry/manager/experiment_manager.py
+++ b/rlberry/manager/experiment_manager.py
@@ -387,7 +387,7 @@ class ExperimentManager:
             )
         if os.path.exists(self.output_dir_):
             logger.warning(
-                "This output directory already exists, the save may change the symbolic link or overwrite the previous Experiment."
+                "This output directory already exists, the save may overwrite the previous Experiment."
             )
 
         # Create list of writers for each agent that will be trained

--- a/rlberry/manager/experiment_manager.py
+++ b/rlberry/manager/experiment_manager.py
@@ -1,6 +1,5 @@
 import concurrent.futures
 from copy import deepcopy
-import errno
 import os
 from pathlib import Path
 import cProfile, pstats
@@ -377,7 +376,7 @@ class ExperimentManager:
             output_dir_ = metadata_utils.RLBERRY_TEMP_DATA_DIR
         else:
             output_dir_ = output_dir
-        self.output_dir_ = Path(output_dir_) / "manager_data"
+        self.output_dir_ = Path(output_dir_) / "manager_data" / self.agent_name
         if outdir_id_style == "unique":
             self.output_dir_ = self.output_dir_ / (
                 self.agent_name + "_" + self.unique_id
@@ -826,8 +825,7 @@ class ExperimentManager:
             handler.dump()
 
         # save
-        filename_symlink = output_dir / Path("manager_obj").with_suffix(".pickle")
-        filename = Path("manager_obj_" + str(self.timestamp_id)).with_suffix(".pickle")
+        filename = Path("manager_obj").with_suffix(".pickle")
         filename = output_dir / filename
         filename.parent.mkdir(parents=True, exist_ok=True)
         try:
@@ -849,16 +847,7 @@ class ExperimentManager:
                 )
         logger.info("The ExperimentManager was saved in : '" + str(filename) + "'")
 
-        try:
-            os.symlink(filename, filename_symlink)
-        except OSError as e:
-            if e.errno == errno.EEXIST:
-                os.remove(filename_symlink)
-                os.symlink(filename, filename_symlink)
-            else:
-                raise e
-
-        return filename_symlink
+        return filename
 
     @classmethod
     def load(cls, filename):
@@ -879,9 +868,6 @@ class ExperimentManager:
             raise ValueError(
                 "The experiment_manager objects should be save in file named 'manager_obj.pickle'"
             )
-
-        if filename.is_symlink():
-            filename = Path(os.readlink(filename)).with_suffix(".pickle")
 
         obj = cls(None, None, None)
 

--- a/rlberry/manager/experiment_manager.py
+++ b/rlberry/manager/experiment_manager.py
@@ -376,7 +376,7 @@ class ExperimentManager:
             output_dir_ = metadata_utils.RLBERRY_TEMP_DATA_DIR
         else:
             output_dir_ = output_dir
-        self.output_dir_ = Path(output_dir_) / "manager_data" / self.agent_name
+        self.output_dir_ = Path(output_dir_) / "manager_data"
         if outdir_id_style == "unique":
             self.output_dir_ = self.output_dir_ / (
                 self.agent_name + "_" + self.unique_id

--- a/rlberry/manager/tests/test_experiment_manager.py
+++ b/rlberry/manager/tests/test_experiment_manager.py
@@ -438,7 +438,7 @@ def test_save_logger_and_warning(caplog):
         path = stats_agent1.save()
         assert str(ExperimentManager_message_begin + str(path) + "'") in caplog.text
 
-        warning_overwrite_message = "This output directory already exists, the save may change the symbolic link or overwrite the previous Experiment."
+        warning_overwrite_message = "This output directory already exists, the save may overwrite the previous Experiment."
         assert not warning_overwrite_message in caplog.text
         stats_agent2 = ExperimentManager(
             DummyAgent,


### PR DESCRIPTION
- Add a save at the end of the fit() of ExperienceManager
- Add a warning when there is a previous save with the same path
- Add a logger.info to display the path of the current save


## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have commented my code, particularly in hard-to-understand areas,
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.
