### PR TITLE
Add tests on imports

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -155,15 +155,19 @@ jobs:
     displayName: 'Install rlberry'
 
   - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest rlberry/tests/test_imports.py
+    displayName: 'pytest imports'
+
+  - script: |
       pip install git+https://github.com/rlberry-py/rlberry-scool.git
       pip install git+https://github.com/rlberry-py/rlberry-research.git
     displayName: 'Install rlberry-scool and rlberry-research'
 
   #ignore les tests qui viennent des extras : torch, experimental, stablebaselines, optuna
   - script: |
-      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
-    displayName: 'pytest'
+    displayName: 'pytest agents and envs'
 
 
 - job: 'macOS_non_editable'
@@ -193,14 +197,18 @@ jobs:
     displayName: 'Install rlberry'
 
   - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest rlberry/tests/test_imports.py
+    displayName: 'pytest imports'
+
+  - script: |
       pip install git+https://github.com/rlberry-py/rlberry-scool.git
       pip install git+https://github.com/rlberry-py/rlberry-research.git
     displayName: 'Install rlberry-scool and rlberry-research'
 
   - script: |
-      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
       pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
-    displayName: 'pytest'
+    displayName: 'pytest agents and envs'
 
 - job: 'windows_non_editable'
   dependsOn: checkPrLabel
@@ -227,11 +235,15 @@ jobs:
     displayName: 'Install rlberry'
 
   - script: |
+      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
+      pytest rlberry/tests/test_imports.py
+    displayName: 'pytest imports'
+
+  - script: |
       pip install git+https://github.com/rlberry-py/rlberry-scool.git
       pip install git+https://github.com/rlberry-py/rlberry-research.git
     displayName: 'Install rlberry-scool and rlberry-research'
 
   - script: |
-      pip install pytest==7.0.1 pytest-azurepipelines pytest-xvfb
-      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
-    displayName: 'pytest'
+      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.pyv
+    displayName: 'pytest agents and envs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -245,5 +245,5 @@ jobs:
     displayName: 'Install rlberry-scool and rlberry-research'
 
   - script: |
-      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.pyv
+      pytest rlberry/tests/test_agents_base.py rlberry/tests/test_envs.py
     displayName: 'pytest agents and envs'

--- a/rlberry/tests/test_imports.py
+++ b/rlberry/tests/test_imports.py
@@ -1,14 +1,9 @@
 def test_imports():
-    try:
-        import rlberry  # noqa
-        from rlberry.manager import (  # noqa
-            ExperimentManager,  # noqa
-            evaluate_agents,  # noqa
-            plot_writer_data,  # noqa
-        )  # noqa
-        from rlberry.agents import AgentWithSimplePolicy  # noqa
-        from rlberry.wrappers import WriterWrapper  # noqa
-
-    except Exception:
-        raise RuntimeError("Fail to call get_params on the environment.")
-        assert False
+    import rlberry  # noqa
+    from rlberry.manager import (  # noqa
+        ExperimentManager,  # noqa
+        evaluate_agents,  # noqa
+        plot_writer_data,  # noqa
+    )  # noqa
+    from rlberry.agents import AgentWithSimplePolicy  # noqa
+    from rlberry.wrappers import WriterWrapper  # noqa

--- a/rlberry/tests/test_imports.py
+++ b/rlberry/tests/test_imports.py
@@ -1,0 +1,14 @@
+def test_imports():
+    try:
+        import rlberry  # noqa
+        from rlberry.manager import (  # noqa
+            ExperimentManager,  # noqa
+            evaluate_agents,  # noqa
+            plot_writer_data,  # noqa
+        )  # noqa
+        from rlberry.agents import AgentWithSimplePolicy  # noqa
+        from rlberry.wrappers import WriterWrapper  # noqa
+
+    except Exception:
+        raise RuntimeError("Fail to call get_params on the environment.")
+        assert False

--- a/rlberry/wrappers/__init__.py
+++ b/rlberry/wrappers/__init__.py
@@ -2,17 +2,3 @@ from .discretize_state import DiscretizeStateWrapper
 from .rescale_reward import RescaleRewardWrapper
 from .writer_utils import WriterWrapper
 from .discrete2onehot import DiscreteToOneHotWrapper
-from .tests import (
-    old_acrobot,
-    old_twinrooms,
-    old_six_room,
-    old_apple_gold,
-    old_ball2d,
-    old_finite_mdp,
-    old_four_room,
-    old_gridworld,
-    old_mountain_car,
-    old_nroom,
-    old_pball,
-    old_pendulum,
-)


### PR DESCRIPTION

## Description
Add tests on imports in the CI specific to rlberry  (no rlberry_scool or rlberry_research)

## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] I have set the label "ready for review" and the checks are all green.
