### PR TITLE
update test to check previous typo unchecked error.

### DIFF
--- a/rlberry/manager/tests/test_experiment_manager.py
+++ b/rlberry/manager/tests/test_experiment_manager.py
@@ -72,16 +72,12 @@ class DummyAgent2(Agent):
 
     # 3 - function to evaluate a model
     def eval(self, n_simulations: int = 2, eval_horizon=3):
+        obs = self.eval_env.reset()
+        action = self.policy(obs)
         episode_returns = [
             0,
         ] * n_simulations
         return np.mean(episode_returns)
-
-    @classmethod
-    def sample_parameters(cls, trial):
-        hyperparameter1 = trial.suggest_categorical("hyperparameter1", [1, 2, 3])
-        hyperparameter2 = trial.suggest_float("hyperparameter2", -10, 10)
-        return {"hyperparameter1": hyperparameter1, "hyperparameter2": hyperparameter2}
 
 
 @pytest.mark.xfail(sys.platform == "win32", reason="bug with windows???")


### PR DESCRIPTION
https://github.com/rlberry-py/rlberry/issues/399

## Description
Need to test Agent, not only AgentWithSimplePolicy

update test to check previous typo unchecked error, previously solve in this commit : https://github.com/rlberry-py/rlberry/commit/25c5f8ae08ffc74be5a0fdf6346b2289f95fbf95

Issue : https://github.com/rlberry-py/rlberry/issues/399


## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.
-->
