### PR TITLE
Plot truncation when no smoothing

### DIFF
--- a/rlberry/manager/plotting.py
+++ b/rlberry/manager/plotting.py
@@ -530,7 +530,7 @@ def plot_synchronized_curves(
     ylabel = y
     assert len(data) > 0, "dataset is empty"
     n_tot_simu = int(data["n_simu"].max())
-    
+
     # check that every simulation have the same xs or truncate
     processed_df = pd.DataFrame()
     for name in np.unique(data["name"]):
@@ -543,11 +543,12 @@ def plot_synchronized_curves(
             if len(x_simu) != len(x_simu_0):
                 logger.warn("x axis is not the same for all the runs, truncating.")
             x_simu_0 = np.intersect1d(x_simu_0, x_simu)
-        df_name = df_name.loc[df_name[xlabel].apply(lambda x : x in x_simu_0)]
-        assert len(df_name)>0, "x_axis are incompatible across runs, you should use smoothing"
+        df_name = df_name.loc[df_name[xlabel].apply(lambda x: x in x_simu_0)]
+        assert (
+            len(df_name) > 0
+        ), "x_axis are incompatible across runs, you should use smoothing"
         processed_df = pd.concat([processed_df, df_name], ignore_index=True)
     data = processed_df
-    
 
     ax, styles, cmap = _prepare_ax(data, ax, linestyles)
 

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -23,7 +23,7 @@ class RandomAgent(AgentWithSimplePolicy):
 
     def fit(self, budget=100, **kwargs):
         observation, info = self.env.reset()
-        for ep in range(budget):
+        for ep in range(budget+np.random.randint(5)): # to simulate having different sizes
             action = self.policy(observation)
             observation, reward, done, _, _ = self.env.step(action)
 

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -15,6 +15,7 @@ from rlberry.agents import AgentWithSimplePolicy
 
 np.random.seed(42)
 
+
 class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"
 

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -13,6 +13,7 @@ from rlberry.manager import plot_writer_data, ExperimentManager, read_writer_dat
 from rlberry.manager.plotting import plot_smoothed_curves, plot_synchronized_curves
 from rlberry.agents import AgentWithSimplePolicy
 
+np.random.seed(42)
 
 class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -23,7 +23,9 @@ class RandomAgent(AgentWithSimplePolicy):
 
     def fit(self, budget=100, **kwargs):
         observation, info = self.env.reset()
-        for ep in range(budget+np.random.randint(5)): # to simulate having different sizes
+        for ep in range(
+            budget + np.random.randint(5)
+        ):  # to simulate having different sizes
             action = self.policy(observation)
             observation, reward, done, _, _ = self.env.step(action)
 


### PR DESCRIPTION

In this PR I change the default behavior of the plot function so that the data are truncated if the x data are not all the same.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
