### PR TITLE
Fix plot and pandas warning

### DIFF
--- a/rlberry/manager/plotting.py
+++ b/rlberry/manager/plotting.py
@@ -162,7 +162,7 @@ def plot_writer_data(
             )
     else:
         data[xtag] = data.index
-    data["n_simu"] = data["n_simu"].astype(int)
+    data.loc[:,"n_simu"] = data["n_simu"].astype(int)
     if sub_sample:
         new_df = pd.DataFrame()
         for name in data["name"].unique():
@@ -308,7 +308,7 @@ def plot_smoothed_curves(
     ylabel = y
     x_values = data[xlabel].values
     min_x, max_x = x_values.min(), x_values.max()
-    n_tot_simu = int(data["n_simu"].max())
+    n_tot_simu = int(data["n_simu"].max())+1
 
     if not isinstance(smoothing_bandwidth, numbers.Number):
         sorted_x = np.sort(np.unique(x_values))
@@ -347,7 +347,6 @@ def plot_smoothed_curves(
             bw = smoothing_bandwidth
 
         Xhat = np.zeros([n_tot_simu, len(xplot)])
-
         for f in range(n_tot_simu):
             X = df_name.loc[df["n_simu"] == f, ylabel].values
             try:
@@ -393,7 +392,7 @@ def plot_smoothed_curves(
             linestyle=(0, styles[id_c]),
         )
 
-        if error_representation == "raw_curves":
+        if (error_representation == "raw_curves") and (n_tot_simu>1):
             for n_simu in range(n_tot_simu):
                 x_simu = df_name.loc[df_name["n_simu"] == n_simu, xlabel].values.astype(
                     float
@@ -403,7 +402,7 @@ def plot_smoothed_curves(
                     ax.plot(x_simu, y, alpha=0.2, label="raw " + name, color=cmap[id_c])
                 else:
                     ax.plot(x_simu, y, alpha=0.25, color=cmap[id_c])
-        else:
+        elif n_tot_simu>1:
             sigma = np.sqrt(np.sum((Xhat - mu) ** 2, axis=0) / (len(Xhat) - 1))
 
             if error_representation == "ci":

--- a/rlberry/manager/plotting.py
+++ b/rlberry/manager/plotting.py
@@ -162,7 +162,7 @@ def plot_writer_data(
             )
     else:
         data[xtag] = data.index
-    data.loc[:,"n_simu"] = data["n_simu"].astype(int)
+    data.loc[:, "n_simu"] = data["n_simu"].astype(int)
     if sub_sample:
         new_df = pd.DataFrame()
         for name in data["name"].unique():
@@ -308,7 +308,7 @@ def plot_smoothed_curves(
     ylabel = y
     x_values = data[xlabel].values
     min_x, max_x = x_values.min(), x_values.max()
-    n_tot_simu = int(data["n_simu"].max())+1
+    n_tot_simu = int(data["n_simu"].max()) + 1
 
     if not isinstance(smoothing_bandwidth, numbers.Number):
         sorted_x = np.sort(np.unique(x_values))
@@ -392,7 +392,7 @@ def plot_smoothed_curves(
             linestyle=(0, styles[id_c]),
         )
 
-        if (error_representation == "raw_curves") and (n_tot_simu>1):
+        if (error_representation == "raw_curves") and (n_tot_simu > 1):
             for n_simu in range(n_tot_simu):
                 x_simu = df_name.loc[df_name["n_simu"] == n_simu, xlabel].values.astype(
                     float
@@ -402,7 +402,7 @@ def plot_smoothed_curves(
                     ax.plot(x_simu, y, alpha=0.2, label="raw " + name, color=cmap[id_c])
                 else:
                     ax.plot(x_simu, y, alpha=0.25, color=cmap[id_c])
-        elif n_tot_simu>1:
+        elif n_tot_simu > 1:
             sigma = np.sqrt(np.sum((Xhat - mu) ** 2, axis=0) / (len(Xhat) - 1))
 
             if error_representation == "ci":
@@ -423,9 +423,10 @@ def plot_smoothed_curves(
                 # Bootstrap estimation of confidence interval
                 if not (np.all(sigma == 0)):
                     for b in range(n_boot):
-                        id_b = np.random.choice(
-                            n_tot_simu, size=n_tot_simu, replace=True
-                        )-1
+                        id_b = (
+                            np.random.choice(n_tot_simu, size=n_tot_simu, replace=True)
+                            - 1
+                        )
                         mustar = np.mean(Xhat[id_b], axis=0)
                         residus = (
                             np.sqrt(len(xplot[sigma != 0]))

--- a/rlberry/manager/plotting.py
+++ b/rlberry/manager/plotting.py
@@ -425,7 +425,7 @@ def plot_smoothed_curves(
                     for b in range(n_boot):
                         id_b = np.random.choice(
                             n_tot_simu, size=n_tot_simu, replace=True
-                        )
+                        )-1
                         mustar = np.mean(Xhat[id_b], axis=0)
                         residus = (
                             np.sqrt(len(xplot[sigma != 0]))

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -15,6 +15,7 @@ from rlberry.agents import AgentWithSimplePolicy
 
 np.random.seed(42)
 
+
 class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"
 

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -109,9 +109,7 @@ class DefaultWriter:
                 df = pd.DataFrame(self._data[tag])
             else:
                 df = pd.concat(
-                    [
-                        df,
-                    ],
+                    [df, pd.DataFrame(self._data[tag])],
                     ignore_index=True,
                 )
         return df

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -105,7 +105,8 @@ class DefaultWriter:
     def data(self):
         df = pd.DataFrame(columns=("name", "tag", "value", "global_step"))
         for tag in self._data:
-            df = pd.concat([df, pd.DataFrame(self._data[tag])], ignore_index=True)
+            if len(self._data[tag])>0:
+                df = pd.concat([df, pd.DataFrame(self._data[tag])], ignore_index=True)
         return df
 
     def set_max_global_step(self, max_global_step):

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -108,7 +108,12 @@ class DefaultWriter:
             if df is None:
                 df = pd.DataFrame(self._data[tag])
             else:
-                df = pd.concat([df, ], ignore_index=True)
+                df = pd.concat(
+                    [
+                        df,
+                    ],
+                    ignore_index=True,
+                )
         return df
 
     def set_max_global_step(self, max_global_step):

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -112,6 +112,9 @@ class DefaultWriter:
                     [df, pd.DataFrame(self._data[tag])],
                     ignore_index=True,
                 )
+        if df is None:
+            # if there are no data, return empty dataframe
+            df = pd.DataFrame()
         return df
 
     def set_max_global_step(self, max_global_step):

--- a/rlberry/utils/writers.py
+++ b/rlberry/utils/writers.py
@@ -103,10 +103,12 @@ class DefaultWriter:
 
     @property
     def data(self):
-        df = pd.DataFrame(columns=("name", "tag", "value", "global_step"))
+        df = None
         for tag in self._data:
-            if len(self._data[tag])>0:
-                df = pd.concat([df, pd.DataFrame(self._data[tag])], ignore_index=True)
+            if df is None:
+                df = pd.DataFrame(self._data[tag])
+            else:
+                df = pd.concat([df, ], ignore_index=True)
         return df
 
     def set_max_global_step(self, max_global_step):


### PR DESCRIPTION
I this PR I fix a bug that did not consider all the seeds when doing the smoothed plot (it forgot one) and I also solve a pandas deprecation warning about concatenation of empty dataframe.

<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
