### PR TITLE
fix typo in example and add valuerror for plot error

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,14 @@ Dev version
 
  * Moving "rendering" to rlberry
 
+*PR #405 #406 #408* 
+
+ * fix plots
+
+*PR #404*
+
+ * add AdaStop
+
 Version 0.7.0
 -------------
 

--- a/examples/plot_smooth.py
+++ b/examples/plot_smooth.py
@@ -116,6 +116,7 @@ for i, error in enumerate(["cb", "raw_curves", "ci", "pi"]):
         tag="action",
         preprocess_func=compute_pseudo_regret,
         title=error,
+        smooth=True,
         error_representation=error,
         ax=axes[i],
         show=False,

--- a/rlberry/manager/plotting.py
+++ b/rlberry/manager/plotting.py
@@ -589,7 +589,7 @@ def plot_synchronized_curves(
                 alpha=0.25,
                 color=cmap[id_c],
             )
-        else:
+        elif error_representation == "raw_curves":
             for n_simu in range(n_tot_simu):
                 x_simu = df_name.loc[df_name["n_simu"] == n_simu, xlabel].values.astype(
                     float
@@ -600,6 +600,8 @@ def plot_synchronized_curves(
                     ax.plot(x_simu, y, alpha=0.2, color=cmap[id_c])
                 else:
                     ax.plot(x_simu, y, alpha=0.25, color=cmap[id_c])
+        else:
+            raise ValueError("Error representation {} not known for non-smoothed plots".format(error_representation))
 
     ax.set_ylabel(ylabel)
     ax.set_xlabel(xlabel)


### PR DESCRIPTION
typo in doc for plot function.
<!---
## Checklist
- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[ ] If updated the changelog if necessary,
- \[ ] I have set the label "ready for review" and the checks are all green.
-->
