### PR TITLE
loading : finding path helper

### DIFF
--- a/docs/basics/userguide/save_load.md
+++ b/docs/basics/userguide/save_load.md
@@ -82,17 +82,17 @@ In this folder, you should find :
 In this example you will load the experiment saved in the part 1.
 
 To load an experiment previously saved, you need to :
-- Locate the file you want to load
+- Locate the file you want to load (you can use the tool function `get_single_path_of_most_recently_trained_experiment_manager_obj_from_path` to get the most recently saved `manager_obj.pickle` from a folder)
 - use the function `load()` from the class [ExperimentManager](rlberry.manager.ExperimentManager.load).
 
 ```python
-import pathlib
 from rlberry.envs import gym_make
 from rlberry.manager.experiment_manager import ExperimentManager
+from rlberry.utils import loading_tools
 
 
-path_to_load = next(
-    pathlib.Path("results").glob("**/manager_obj.pickle")
+path_to_load = loading_tools.get_single_path_of_most_recently_trained_experiment_manager_obj_from_path(
+    "results"
 )  # find the path to the "manager_obj.pickle"
 
 loaded_experiment_manager = ExperimentManager.load(path_to_load)  # load the experiment

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,10 @@ Changelog
 Dev version
 -----------
 
+ *PR #468*
+
+* New tool to find the path of the 'manager_obj.pickle' more easily: https://github.com/rlberry-py/rlberry/issues/407
+
  *PR #467*
 
  * Allow the save as Gif for gymnasium env (make_gym) : https://github.com/rlberry-py/rlberry/issues/453

--- a/rlberry/manager/tests/test_evaluation.py
+++ b/rlberry/manager/tests/test_evaluation.py
@@ -6,7 +6,6 @@ from rlberry_scool.envs import Chain
 from rlberry.wrappers import WriterWrapper
 import tempfile
 import numpy as np
-import time
 
 
 class RandomAgent(AgentWithSimplePolicy):
@@ -30,75 +29,6 @@ class RandomAgent(AgentWithSimplePolicy):
 
 class RandomAgent2(RandomAgent):
     name = "RandomAgent2"
-
-
-def _create_and_fit_experiment_manager(
-    output_dir, outdir_id_style, agent_class=RandomAgent
-):
-    env_ctor = Chain
-    env_kwargs = dict(L=3, fail_prob=0.5)
-
-    manager = ExperimentManager(
-        agent_class,
-        (env_ctor, env_kwargs),
-        fit_budget=15,
-        n_fit=3,
-        output_dir=output_dir,
-        outdir_id_style=outdir_id_style,
-        seed=42,
-    )
-    manager.fit()
-    saved_path = manager.save()
-
-    return saved_path
-
-
-def _create_and_fit_5_experiment_manager(
-    output_dir, outdir_id_style, agent_class=RandomAgent
-):
-    list_path = []
-
-    for i in range(0, 5):
-        saved_path = _create_and_fit_experiment_manager(
-            output_dir, outdir_id_style, agent_class
-        )
-        list_path.append(saved_path)
-        time.sleep(2)
-    return list_path
-
-
-@pytest.mark.parametrize("outdir_id_style", [None, "unique", "timestamp"])
-def test_get_latest_pickle_manager_obj(outdir_id_style):
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        output_dir = tmpdirname + "/rlberry_data"
-        path_list = _create_and_fit_5_experiment_manager(output_dir, outdir_id_style)
-
-        expected_result = path_list[-1]  # latest added, is the more recent
-        function_result = evaluation._get_latest_pickle_manager_obj(output_dir)
-
-        assert expected_result == function_result
-
-
-@pytest.mark.parametrize("outdir_id_style", [None, "unique", "timestamp"])
-def test_get_paths_multi_latest_pickle_manager_obj(outdir_id_style):
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        output_dir = tmpdirname + "/rlberry_data"
-        path_list = _create_and_fit_5_experiment_manager(
-            output_dir, outdir_id_style, RandomAgent
-        )
-        expected_result1 = path_list[-1]  # latest added, is the more recent
-        path_list = _create_and_fit_5_experiment_manager(
-            output_dir, outdir_id_style, RandomAgent2
-        )
-        expected_result2 = path_list[-1]  # latest added, is the more recent
-
-        function_result = evaluation._get_paths_multi_latest_pickle_manager_obj(
-            output_dir
-        )
-
-        assert len(function_result) == 2
-        assert expected_result1 in function_result
-        assert expected_result2 in function_result
 
 
 @pytest.mark.parametrize("many_agent_by_str_datasource", [True, False])

--- a/rlberry/utils/check_agent.py
+++ b/rlberry/utils/check_agent.py
@@ -4,7 +4,7 @@ from rlberry.seeding import set_external_seed
 import tempfile
 import os
 from rlberry.envs.gym_make import gym_make
-import pathlib
+from rlberry.utils import loading_tools
 
 
 SEED = 42
@@ -288,7 +288,9 @@ def _check_save_load_with_manager(agent, env="continuous_state", init_kwargs=Non
         manager.save()
         assert os.path.exists(tmpdirname)
 
-        path_to_load = next(pathlib.Path(tmpdirname).glob("**/manager_obj.pickle"))
+        path_to_load = loading_tools.get_single_path_of_most_recently_trained_experiment_manager_obj_from_path(
+            tmpdirname
+        )
         loaded_experiment_manager = ExperimentManager.load(path_to_load)
         assert loaded_experiment_manager
 

--- a/rlberry/utils/loading_tools.py
+++ b/rlberry/utils/loading_tools.py
@@ -1,0 +1,98 @@
+import os
+
+import pathlib
+import rlberry
+
+logger = rlberry.logger
+
+
+def get_single_path_of_most_recently_trained_experiment_manager_obj_from_path(
+    path_to_explore,
+):
+    """
+    Get the path to the latest manager_obj.pickle (whatever the agent) in a directory (sort them by reverse last modification date, and give the first).
+
+    Parameters
+    ----------
+    path_to_explore str: the path where the ExperimentManager was saved... (the parent folder of the manager_obj.pickle)
+
+    """
+    paths = list(
+        pathlib.Path(path_to_explore).glob("**" + os.sep + "manager_obj.pickle")
+    )
+    paths.sort(
+        key=lambda x: os.path.getmtime(x), reverse=True
+    )  # Sort based on file last modification time
+    return paths[0]
+
+
+def get_all_path_of_most_recently_trained_experiments_manager_obj_from_path(
+    path_to_explore,
+):
+    """
+    Get the path to all the more recently updated/created manager_obj.pickle (by agent) in a directory (sort them by reverse last modification date, and give the first).
+
+    Parameters
+    ----------
+    path_to_explore str: the path where the ExperimentManager was saved... (the parent folder of the manager_obj.pickle)
+
+    ----------
+    return: list with the path of all the more recently updated/created manager_obj.pickle by different agent.
+
+    """
+    dict_of_all_exp = get_dict_of_all_experiment_manager_obj_from_path(path_to_explore)
+
+    paths_to_return = []
+    for key, value in dict_of_all_exp.items():
+        sorted_values = sorted(value, key=lambda x: os.path.getmtime(x), reverse=True)
+        paths_to_return.append(sorted_values[0])
+    return paths_to_return
+
+
+def get_dict_of_all_experiment_manager_obj_from_path(path_to_explore):
+    """
+    Find the paths of all the manager_obj.pickle contained in a directory
+
+    Parameters
+    ----------
+    path_to_explore str: the path where the ExperimentManager were saved... (the parent folder of all the manager_obj.pickle)
+
+    ----------
+    return: Dict with the path of all the manager_obj.pickle
+
+    Dict format :
+    key = Agent name
+    value = [(path1,date1),(path2,date2),...]
+    """
+
+    # get all the "manager_obj.pickle" from the directory
+    all_paths = list(
+        pathlib.Path(path_to_explore).glob("**" + os.sep + "manager_obj.pickle")
+    )
+
+    # isolate the name of all the agent of directory
+    list_agent_name = []
+    for path in all_paths:
+        half_split = str(path).split(os.sep + "manager_data" + os.sep)[-1]
+        list_agent_name.append(half_split.split("_")[0])
+    list_unique_agent_name = list(set(list_agent_name))
+
+    # for each of this agent, get the latest manager_obj.pickle (by finding all, and keep the first after sorting by last modification time).
+    dict_to_return = {}
+    for unique_name in list_unique_agent_name:
+        regex_to_search = (
+            "**"
+            + os.sep
+            + "manager_data"
+            + os.sep
+            + ""
+            + unique_name
+            + "_*"
+            + os.sep
+            + "manager_obj.pickle"
+        )
+        dict_to_return[unique_name] = list(
+            pathlib.Path(path_to_explore).glob(regex_to_search)
+        )
+
+    return dict_to_return

--- a/rlberry/utils/loading_tools.py
+++ b/rlberry/utils/loading_tools.py
@@ -62,7 +62,7 @@ def get_dict_of_all_experiment_manager_obj_from_path(path_to_explore):
 
     Dict format :
     key = Agent name
-    value = [(path1,date1),(path2,date2),...]
+    value = list of paths for this agent : [path1,path2,...]
     """
 
     # get all the "manager_obj.pickle" from the directory

--- a/rlberry/utils/tests/test_loading_tools.py
+++ b/rlberry/utils/tests/test_loading_tools.py
@@ -1,0 +1,107 @@
+import pytest
+from rlberry.agents import AgentWithSimplePolicy
+from rlberry.utils import loading_tools
+from rlberry.manager import ExperimentManager
+from rlberry_scool.envs import Chain
+from rlberry.wrappers import WriterWrapper
+import tempfile
+import numpy as np
+import time
+
+
+class RandomAgent(AgentWithSimplePolicy):
+    name = "RandomAgent"
+
+    def __init__(self, env, **kwargs):
+        AgentWithSimplePolicy.__init__(self, env, **kwargs)
+        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+
+    def fit(self, budget=100, **kwargs):
+        observation, info = self.env.reset()
+        for ep in range(
+            budget + np.random.randint(5)
+        ):  # to simulate having different sizes
+            action = self.policy(observation)
+            observation, reward, done, _, _ = self.env.step(action)
+
+    def policy(self, observation):
+        return self.env.action_space.sample()  # choose an action at random
+
+
+class RandomAgent2(RandomAgent):
+    name = "RandomAgent2"
+
+
+def _create_and_fit_experiment_manager(
+    output_dir, outdir_id_style, agent_class=RandomAgent
+):
+    env_ctor = Chain
+    env_kwargs = dict(L=3, fail_prob=0.5)
+
+    manager = ExperimentManager(
+        agent_class,
+        (env_ctor, env_kwargs),
+        fit_budget=15,
+        n_fit=3,
+        output_dir=output_dir,
+        outdir_id_style=outdir_id_style,
+        seed=42,
+    )
+    manager.fit()
+    saved_path = manager.save()
+
+    return saved_path
+
+
+def _create_and_fit_5_experiment_manager(
+    output_dir, outdir_id_style, agent_class=RandomAgent
+):
+    list_path = []
+
+    for i in range(0, 5):
+        saved_path = _create_and_fit_experiment_manager(
+            output_dir, outdir_id_style, agent_class
+        )
+        list_path.append(saved_path)
+        time.sleep(2)
+    return list_path
+
+
+@pytest.mark.parametrize("outdir_id_style", [None, "unique", "timestamp"])
+def test_get_single_path_of_most_recently_trained_experiment_manager_obj_from_path(
+    outdir_id_style,
+):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        output_dir = tmpdirname + "/rlberry_data"
+        path_list = _create_and_fit_5_experiment_manager(output_dir, outdir_id_style)
+
+        expected_result = path_list[-1]  # latest added, is the more recent
+        function_result = loading_tools.get_single_path_of_most_recently_trained_experiment_manager_obj_from_path(
+            output_dir
+        )
+
+        assert expected_result == function_result
+
+
+@pytest.mark.parametrize("outdir_id_style", [None, "unique", "timestamp"])
+def test_get_all_path_of_most_recently_trained_experiments_manager_obj_from_path(
+    outdir_id_style,
+):
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        output_dir = tmpdirname + "/rlberry_data"
+        path_list = _create_and_fit_5_experiment_manager(
+            output_dir, outdir_id_style, RandomAgent
+        )
+        expected_result1 = path_list[-1]  # latest added, is the more recent
+        path_list = _create_and_fit_5_experiment_manager(
+            output_dir, outdir_id_style, RandomAgent2
+        )
+        expected_result2 = path_list[-1]  # latest added, is the more recent
+
+        function_result = loading_tools.get_all_path_of_most_recently_trained_experiments_manager_obj_from_path(
+            output_dir
+        )
+
+        assert len(function_result) == 2
+        assert expected_result1 in function_result
+        assert expected_result2 in function_result


### PR DESCRIPTION

Give a tool to easily find the 'manager_obj.pickle' files.
linked to this issue : https://github.com/rlberry-py/rlberry/issues/407



## Description

Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context, in particular link the relevant issue if it is appropriate.
List any dependencies that are required for this change.


## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have commented my code, particularly in hard-to-understand areas,
- \[x] I have made corresponding changes to the documentation,
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.

