### PR TITLE
Stablebaseline Writer compatibility

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -185,4 +185,3 @@ Environment Wrappers
   wrappers.discretize_state.DiscretizeStateWrapper
   wrappers.gym_utils.OldGymCompatibilityWrapper
   wrappers.RescaleRewardWrapper
-  wrappers.WriterWrapper

--- a/docs/basics/quick_start_rl/quickstart.md
+++ b/docs/basics/quick_start_rl/quickstart.md
@@ -222,22 +222,6 @@ gathered during learning, instead of the regret.
 First, we have to record the reward during the fit as this is not done
 automatically. To do this, we can use the `writer_extra` optional parameter.
 
-```python
-class RandomAgent2(RandomAgent):
-    name = "RandomAgent2"
-
-    def __init__(self, env, **kwargs):
-        RandomAgent.__init__(self, env, **kwargs)
-
-
-class UCBVIAgent2(UCBVIAgent):
-    name = "UCBVIAgent2"
-
-    def __init__(self, env, **kwargs):
-        UCBVIAgent.__init__(self, env, **kwargs)
-```
-
-
 Then, we fit the two agents.
 
 ```python
@@ -246,21 +230,23 @@ random_params = {"writer_extra": "reward"}
 
 # Create ExperimentManager for UCBI to fit 10 agents
 ucbvi_stats = ExperimentManager(
-    UCBVIAgent2,
+    UCBVIAgent,
     (env_ctor, env_kwargs),
     fit_budget=50,
     init_kwargs=ucbvi_params,
     n_fit=10,
+    agent_name="UCBVIAgent2",
 )
 ucbvi_stats.fit()
 
 # Create ExperimentManager for baseline to fit 10 agents
 baseline_stats = ExperimentManager(
-    RandomAgent2,
+    RandomAgent,
     (env_ctor, env_kwargs),
     fit_budget=5000,
     init_kwargs=random_params,
     n_fit=10,
+    agent_name="RandomAgent2",
 )
 baseline_stats.fit()
 ```

--- a/docs/basics/quick_start_rl/quickstart.md
+++ b/docs/basics/quick_start_rl/quickstart.md
@@ -227,20 +227,23 @@ class RandomAgent2(RandomAgent):
     name = "RandomAgent2"
 
     def __init__(self, env, **kwargs):
-        RandomAgent.__init__(self, env, writer_extra="reward", **kwargs)
+        RandomAgent.__init__(self, env, **kwargs)
 
 
 class UCBVIAgent2(UCBVIAgent):
     name = "UCBVIAgent2"
 
     def __init__(self, env, **kwargs):
-        UCBVIAgent.__init__(self, env, writer_extra="reward", **kwargs)
+        UCBVIAgent.__init__(self, env, **kwargs)
 ```
 
 
 Then, we fit the two agents.
 
 ```python
+ucbvi_params["writer_extra"] = "reward"
+random_params = {"writer_extra": "reward"}
+
 # Create ExperimentManager for UCBI to fit 10 agents
 ucbvi_stats = ExperimentManager(
     UCBVIAgent2,
@@ -256,6 +259,7 @@ baseline_stats = ExperimentManager(
     RandomAgent2,
     (env_ctor, env_kwargs),
     fit_budget=5000,
+    init_kwargs=random_params,
     n_fit=10,
 )
 baseline_stats.fit()

--- a/docs/basics/quick_start_rl/quickstart.md
+++ b/docs/basics/quick_start_rl/quickstart.md
@@ -220,9 +220,7 @@ cannot compute the optimal policy, we could simply compare the rewards
 gathered during learning, instead of the regret.
 
 First, we have to record the reward during the fit as this is not done
-automatically. To do this, we can use the
-[WriterWrapper](rlberry.wrappers.writer_utils.WriterWrapper)
-module, or simply the [writer](rlberry.agents.Agent.writer) attribute.
+automatically. To do this, we can use the `writer_extra` optional parameter.
 
 ```python
 class RandomAgent2(RandomAgent):

--- a/docs/basics/quick_start_rl/quickstart.md
+++ b/docs/basics/quick_start_rl/quickstart.md
@@ -25,7 +25,6 @@ from rlberry.manager import (
     plot_writer_data,
     read_writer_data,
 )
-from rlberry.wrappers import WriterWrapper
 ```
 
 Choosing an RL environment
@@ -230,16 +229,14 @@ class RandomAgent2(RandomAgent):
     name = "RandomAgent2"
 
     def __init__(self, env, **kwargs):
-        RandomAgent.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        RandomAgent.__init__(self, env, writer_extra="reward", **kwargs)
 
 
 class UCBVIAgent2(UCBVIAgent):
     name = "UCBVIAgent2"
 
     def __init__(self, env, **kwargs):
-        UCBVIAgent.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        UCBVIAgent.__init__(self, env, writer_extra="reward", **kwargs)
 ```
 
 

--- a/docs/basics/userguide/logging.md
+++ b/docs/basics/userguide/logging.md
@@ -100,12 +100,10 @@ As you can see, on the previous output, you don't have the "INFO" output anymore
 
 
 ## Writer
-To keep informations during and after the experiment, rlberry use a 'writer'. The writer is stored inside the [Agent](agent_page), and is updated in its fit() function.
+To keep information during and after the experiment, rlberry use a 'writer'. The writer is stored inside the [Agent](agent_page), and is updated in its fit() function.
 
 By default (with the [Agent interface](rlberry.agents.Agent)), the writer is [DefaultWriter](rlberry.utils.writers.DefaultWriter).
-
-To keep informations about the environment inside the writer, you can wrap the environment inside [WriterWrapper](rlberry.wrappers.WriterWrapper).
-
+You can add information about the environment's `reward` and `action` with the optional parameter `writer_extra` during the agent initialization.
 
 To get the data, saved during an experiment, in a Pandas DataFrame, you can use [plot_writer_data](rlberry.manager.plot_writer_data) on the [ExperimentManager](rlberry.manager.ExperimentManager) (or a list of them).
 Example [here](../../auto_examples/demo_bandits/plot_mirror_bandit).

--- a/docs/basics/userguide/logging.md
+++ b/docs/basics/userguide/logging.md
@@ -100,10 +100,16 @@ As you can see, on the previous output, you don't have the "INFO" output anymore
 
 
 ## Writer
-To keep information during and after the experiment, rlberry use a 'writer'. The writer is stored inside the [Agent](agent_page), and is updated in its fit() function.
+To keep information during and after the experiment, rlberry uses a 'writer'. The writer is stored inside the [Agent](agent_page), and is updated in its fit() function.
 
 By default (with the [Agent interface](rlberry.agents.Agent)), the writer is [DefaultWriter](rlberry.utils.writers.DefaultWriter).
 You can add information about the environment's `reward` and `action` with the optional parameter `writer_extra` during the agent initialization.
+
+In the previous example, to get the reward, this would give (parameter for the ExperimentManager):
+```python
+init_kwargs = dict(algo_cls=PPO, verbose=1, writer_extra="reward")
+```
+
 
 To get the data, saved during an experiment, in a Pandas DataFrame, you can use [plot_writer_data](rlberry.manager.plot_writer_data) on the [ExperimentManager](rlberry.manager.ExperimentManager) (or a list of them).
 Example [here](../../auto_examples/demo_bandits/plot_mirror_bandit).

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,11 @@ Changelog
 Dev version
 -----------
 
+
+ *PR #470*
+
+* Integrates the writer directly into the base "Agent" via an option: https://github.com/rlberry-py/rlberry/issues/457
+
  *PR #468*
 
 * New tool to find the path of the 'manager_obj.pickle' more easily: https://github.com/rlberry-py/rlberry/issues/407

--- a/examples/comparison_agents.py
+++ b/examples/comparison_agents.py
@@ -16,7 +16,6 @@ import numpy as np
 from rlberry.manager.comparison import compare_agents
 from rlberry.manager import AgentManager
 from rlberry_research.envs.bandits import BernoulliBandit
-from rlberry.wrappers import WriterWrapper
 from rlberry_research.agents.bandits import (
     IndexAgent,
     makeBoundedMOSSIndex,
@@ -42,8 +41,7 @@ class UCBAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, _ = makeBoundedUCBIndex()
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        IndexAgent.__init__(self, env, index, writer_extra="reward", **kwargs)
 
 
 class ETCAgent(IndexAgent):
@@ -51,9 +49,8 @@ class ETCAgent(IndexAgent):
 
     def __init__(self, env, m=20, **kwargs):
         index, _ = makeETCIndex(A, m)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self, env, index, writer_extra="action_and_reward", **kwargs
         )
 
 
@@ -62,9 +59,8 @@ class MOSSAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, _ = makeBoundedMOSSIndex(T, A)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self, env, index, writer_extra="action_and_reward", **kwargs
         )
 
 
@@ -73,8 +69,14 @@ class NPTSAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, tracker_params = makeBoundedNPTSIndex()
-        IndexAgent.__init__(self, env, index, tracker_params=tracker_params, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        IndexAgent.__init__(
+            self,
+            env,
+            index,
+            writer_extra="reward",
+            tracker_params=tracker_params,
+            **kwargs,
+        )
 
 
 Agents_class = [MOSSAgent, NPTSAgent, UCBAgent, ETCAgent]

--- a/examples/demo_bandits/plot_TS_bandit.py
+++ b/examples/demo_bandits/plot_TS_bandit.py
@@ -21,7 +21,6 @@ from rlberry_research.agents.bandits import (
     makeGaussianPrior,
 )
 from rlberry.manager import ExperimentManager, plot_writer_data
-from rlberry.wrappers import WriterWrapper
 
 
 # Bernoulli
@@ -36,8 +35,7 @@ class BernoulliTSAgent(TSAgent):
 
     def __init__(self, env, **kwargs):
         prior, _ = makeBetaPrior()
-        TSAgent.__init__(self, env, prior, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        TSAgent.__init__(self, env, prior, writer_extra="action", **kwargs)
 
 
 class BoundedUCBAgent(IndexAgent):
@@ -47,8 +45,7 @@ class BoundedUCBAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, _ = makeBoundedUCBIndex(0, 1)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        IndexAgent.__init__(self, env, index, writer_extra="action", **kwargs)
 
 
 # Parameters of the problem
@@ -101,8 +98,7 @@ class GaussianTSAgent(TSAgent):
 
     def __init__(self, env, sigma=1.0, **kwargs):
         prior, _ = makeGaussianPrior(sigma)
-        TSAgent.__init__(self, env, prior, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        TSAgent.__init__(self, env, prior, writer_extra="action", **kwargs)
 
 
 class GaussianUCBAgent(IndexAgent):
@@ -112,8 +108,7 @@ class GaussianUCBAgent(IndexAgent):
 
     def __init__(self, env, sigma=1.0, **kwargs):
         index, _ = makeSubgaussianUCBIndex(sigma)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        IndexAgent.__init__(self, env, index, writer_extra="action", **kwargs)
 
 
 # Parameters of the problem

--- a/examples/demo_bandits/plot_compare_index_bandits.py
+++ b/examples/demo_bandits/plot_compare_index_bandits.py
@@ -10,7 +10,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from rlberry_research.envs.bandits import BernoulliBandit
 from rlberry.manager import ExperimentManager, plot_writer_data
-from rlberry.wrappers import WriterWrapper
 from rlberry_research.agents.bandits import (
     IndexAgent,
     RandomizedAgent,
@@ -44,9 +43,8 @@ class UCBAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, _ = makeBoundedUCBIndex()
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self, env, index, writer_extra="action_and_reward", **kwargs
         )
 
 
@@ -55,9 +53,13 @@ class UCBVAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, params = makeBoundedUCBVIndex()
-        IndexAgent.__init__(self, env, index, tracker_params=params, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self,
+            env,
+            index,
+            writer_extra="action_and_reward",
+            tracker_params=params,
+            **kwargs
         )
 
 
@@ -66,9 +68,8 @@ class ETCAgent(IndexAgent):
 
     def __init__(self, env, m=20, **kwargs):
         index, _ = makeETCIndex(A, m)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self, env, index, writer_extra="action_and_reward", **kwargs
         )
 
 
@@ -77,9 +78,8 @@ class MOSSAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, _ = makeBoundedMOSSIndex(T, A)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self, env, index, writer_extra="action_and_reward", **kwargs
         )
 
 
@@ -88,9 +88,13 @@ class IMEDAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, tracker_params = makeBoundedIMEDIndex()
-        IndexAgent.__init__(self, env, index, tracker_params=tracker_params, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self,
+            env,
+            index,
+            writer_extra="action_and_reward",
+            tracker_params=tracker_params,
+            **kwargs
         )
 
 
@@ -99,9 +103,13 @@ class NPTSAgent(IndexAgent):
 
     def __init__(self, env, **kwargs):
         index, tracker_params = makeBoundedNPTSIndex()
-        IndexAgent.__init__(self, env, index, tracker_params=tracker_params, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        IndexAgent.__init__(
+            self,
+            env,
+            index,
+            writer_extra="action_and_reward",
+            tracker_params=tracker_params,
+            **kwargs
         )
 
 
@@ -111,10 +119,12 @@ class EXP3Agent(RandomizedAgent):
     def __init__(self, env, **kwargs):
         prob, tracker_params = makeEXP3Index()
         RandomizedAgent.__init__(
-            self, env, prob, tracker_params=tracker_params, **kwargs
-        )
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+            self,
+            env,
+            prob,
+            writer_extra="action_and_reward",
+            tracker_params=tracker_params,
+            **kwargs
         )
 
 

--- a/examples/demo_bandits/plot_exp3_bandit.py
+++ b/examples/demo_bandits/plot_exp3_bandit.py
@@ -16,7 +16,6 @@ from rlberry_research.agents.bandits import (
     makeBetaPrior,
 )
 from rlberry.manager import ExperimentManager, plot_writer_data
-from rlberry.wrappers import WriterWrapper
 
 
 # Agents definition
@@ -28,9 +27,13 @@ class EXP3Agent(RandomizedAgent):
     def __init__(self, env, **kwargs):
         prob, tracker_params = makeEXP3Index()
         RandomizedAgent.__init__(
-            self, env, prob, tracker_params=tracker_params, **kwargs
+            self,
+            env,
+            prob,
+            writer_extra="action",
+            tracker_params=tracker_params,
+            **kwargs
         )
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
 
 
 class BernoulliTSAgent(TSAgent):
@@ -40,8 +43,7 @@ class BernoulliTSAgent(TSAgent):
 
     def __init__(self, env, **kwargs):
         prior, _ = makeBetaPrior()
-        TSAgent.__init__(self, env, prior, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        TSAgent.__init__(self, env, prior, writer_extra="action", **kwargs)
 
 
 # Parameters of the problem

--- a/examples/demo_bandits/plot_mirror_bandit.py
+++ b/examples/demo_bandits/plot_mirror_bandit.py
@@ -17,7 +17,6 @@ import numpy as np
 from rlberry.manager import ExperimentManager, read_writer_data
 from rlberry.envs.interface import Model
 from rlberry_research.agents.bandits import BanditWithSimplePolicy
-from rlberry.wrappers import WriterWrapper
 import rlberry.spaces as spaces
 
 import requests
@@ -117,9 +116,8 @@ class SeqHalvAgent(BanditWithSimplePolicy):
     name = "SeqHalvAgent"
 
     def __init__(self, env, **kwargs):
-        BanditWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(
-            self.env, self.writer, write_scalar="action_and_reward"
+        BanditWithSimplePolicy.__init__(
+            self, env, writer_extra="action_and_reward", **kwargs
         )
 
     def fit(self, budget=None, **kwargs):

--- a/examples/demo_bandits/plot_ucb_bandit.py
+++ b/examples/demo_bandits/plot_ucb_bandit.py
@@ -11,7 +11,6 @@ from rlberry_research.envs.bandits import NormalBandit
 from rlberry_research.agents.bandits import IndexAgent, makeSubgaussianUCBIndex
 from rlberry.manager import ExperimentManager, plot_writer_data
 import matplotlib.pyplot as plt
-from rlberry.wrappers import WriterWrapper
 
 
 # Agents definition
@@ -24,8 +23,7 @@ class UCBAgent(IndexAgent):
 
     def __init__(self, env, sigma=1, **kwargs):
         index, _ = makeSubgaussianUCBIndex(sigma)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        IndexAgent.__init__(self, env, index, writer_extra="action", **kwargs)
 
 
 # Parameters of the problem

--- a/examples/plot_smooth.py
+++ b/examples/plot_smooth.py
@@ -17,7 +17,6 @@ from rlberry_research.agents.bandits import (
 )
 from rlberry.manager import ExperimentManager, plot_writer_data
 import matplotlib.pyplot as plt
-from rlberry.wrappers import WriterWrapper
 
 
 # Parameters of the problem
@@ -34,8 +33,7 @@ class UCBAgent(IndexAgent):
 
     def __init__(self, env, sigma=1, **kwargs):
         index, _ = makeSubgaussianUCBIndex(sigma)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        IndexAgent.__init__(self, env, index, writer_extra="action", **kwargs)
 
 
 class MOSSAgent(IndexAgent):
@@ -45,8 +43,7 @@ class MOSSAgent(IndexAgent):
 
     def __init__(self, env, sigma=1, **kwargs):
         index, _ = makeSubgaussianMOSSIndex(T, len(means), sigma=sigma)
-        IndexAgent.__init__(self, env, index, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="action")
+        IndexAgent.__init__(self, env, index, writer_extra="action", **kwargs)
 
 
 # Construction of the experiment

--- a/examples/plot_writer_wrapper.py
+++ b/examples/plot_writer_wrapper.py
@@ -22,7 +22,6 @@ during the fit of the agent and then use the plot utils.
 
 import numpy as np
 
-from rlberry.wrappers import WriterWrapper
 from rlberry_scool.envs import GridWorld
 from rlberry.manager import plot_writer_data, ExperimentManager
 from rlberry_scool.agents import UCBVIAgent
@@ -36,11 +35,7 @@ class VIAgent(UCBVIAgent):
     name = "UCBVIAgent"
 
     def __init__(self, env, **kwargs):
-        UCBVIAgent.__init__(self, env, horizon=50, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
-        # we could also record actions with
-        # self.env = WriterWrapper(self.env, self.writer,
-        #                          write_scalar = "action")
+        UCBVIAgent.__init__(self, env, writer_extra="reward", horizon=50, **kwargs)
 
 
 env_ctor = GridWorld

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -478,6 +478,8 @@ class AgentWithSimplePolicy(Agent):
         to create files/directories for the agent to log data safely..
     thread_shared_data : dict
         Data shared by agent instances among different threads.
+    writer_extra (through class Agent) : str in {"reward", "action", "action_and_reward"},
+        Scalar that will be recorded in the writer.
 
     Examples
     --------

--- a/rlberry/agents/agent.py
+++ b/rlberry/agents/agent.py
@@ -74,6 +74,8 @@ class Agent(ABC):
     unique_id : str
         Unique identifier for the agent instance. Can be used, for example,
         to create files/directories for the agent to log data safely.
+    writer_extra : str in {"reward", "action", "action_and_reward"},
+        Scalar that will be recorded in the writer.
     thread_shared_data : dict
         Data shared by agent instances among different threads.
     """
@@ -88,6 +90,7 @@ class Agent(ABC):
         compress_pickle: bool = True,
         seeder: Optional[types.Seed] = None,
         output_dir: Optional[str] = None,
+        writer_extra: str = None,
         _execution_metadata: Optional[metadata_utils.ExecutionMetadata] = None,
         _default_writer_kwargs: Optional[dict] = None,
         _thread_shared_data: Optional[dict] = None,
@@ -120,6 +123,9 @@ class Agent(ABC):
 
         # shared data among threads
         self._thread_shared_data = _thread_shared_data
+
+        if writer_extra:
+            self.env = _WriterWrapper(self.env, self.writer, write_scalar=writer_extra)
 
     @property
     def writer(self):
@@ -729,3 +735,48 @@ class AgentTorch(Agent):
 
         obj.device = device
         return obj
+
+
+from rlberry.envs import Wrapper
+
+
+# copy of the WriterWrapper class, but in private
+class _WriterWrapper(Wrapper):
+    """
+    Wrapper for environment to automatically record reward or action in writer.
+
+    Parameters
+    ----------
+    env : gymnasium.Env or tuple (constructor, kwargs)
+        Environment used to fit the agent.
+
+    writer : object, default: None
+        Writer object (e.g. tensorboard SummaryWriter).
+
+    write_scalar : string in {"reward", "action", "action_and_reward"},
+                    default = "reward"
+        Scalar that will be recorded in the writer.
+
+    """
+
+    def __init__(self, env, writer, write_scalar="reward"):
+        Wrapper.__init__(self, env)
+        self.writer = writer
+        self.write_scalar = write_scalar
+        self.iteration_ = 0
+
+    def step(self, action):
+        observation, reward, terminated, truncated, info = self.env.step(action)
+
+        self.iteration_ += 1
+        if self.write_scalar == "reward":
+            self.writer.add_scalar("reward", reward, self.iteration_)
+        elif self.write_scalar == "action":
+            self.writer.add_scalar("action", action, self.iteration_)
+        elif self.write_scalar == "action_and_reward":
+            self.writer.add_scalar("reward", reward, self.iteration_)
+            self.writer.add_scalar("action", action, self.iteration_)
+        else:
+            raise ValueError("write_scalar %s is not known" % (self.write_scalar))
+
+        return observation, reward, terminated, truncated, info

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -122,6 +122,7 @@ class StableBaselinesAgent(AgentWithSimplePolicy):
         "_execution_metadata",
         "_default_writer_kwargs",
         "_thread_shared_data",
+        "writer_extra",
     ]
 
     def __init__(
@@ -140,12 +141,14 @@ class StableBaselinesAgent(AgentWithSimplePolicy):
         _thread_shared_data: Optional[dict] = None,
         **kwargs,
     ):
+        writer_extra = kwargs.get("writer_extra")
         super(StableBaselinesAgent, self).__init__(
             env,
             eval_env=eval_env,
             copy_env=copy_env,
             seeder=seeder,
             output_dir=output_dir,
+            writer_extra=writer_extra,
             _execution_metadata=_execution_metadata,
             _default_writer_kwargs=_default_writer_kwargs,
             _thread_shared_data=_thread_shared_data,

--- a/rlberry/agents/stable_baselines/stable_baselines.py
+++ b/rlberry/agents/stable_baselines/stable_baselines.py
@@ -94,6 +94,8 @@ class StableBaselinesAgent(AgentWithSimplePolicy):
         Seeder/seed for random number generation.
     output_dir : str or Path
         Directory that the agent can use to store data.
+    writer_extra (through class Agent) : str in {"reward", "action", "action_and_reward"},
+        Scalar that will be recorded in the writer.
     _execution_metadata : ExecutionMetadata, optional
         Extra information about agent execution (e.g. about which is the process id where the agent is running).
         Used by :class:`~rlberry.manager.ExperimentManager`.

--- a/rlberry/manager/tests/test_evaluation.py
+++ b/rlberry/manager/tests/test_evaluation.py
@@ -3,7 +3,6 @@ from rlberry.agents import AgentWithSimplePolicy
 from rlberry.manager import evaluation
 from rlberry.manager import ExperimentManager
 from rlberry_scool.envs import Chain
-from rlberry.wrappers import WriterWrapper
 import tempfile
 import numpy as np
 
@@ -12,8 +11,7 @@ class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"
 
     def __init__(self, env, **kwargs):
-        AgentWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        AgentWithSimplePolicy.__init__(self, env, writer_extra="reward", **kwargs)
 
     def fit(self, budget=100, **kwargs):
         observation, info = self.env.reset()

--- a/rlberry/manager/tests/test_experiment_manager.py
+++ b/rlberry/manager/tests/test_experiment_manager.py
@@ -13,7 +13,6 @@ from rlberry.manager import (
     preset_manager,
     read_writer_data,
 )
-from rlberry.wrappers import WriterWrapper
 from rlberry.utils.check_agent import check_save_load
 
 
@@ -447,8 +446,7 @@ def test_logs(style_log):
 
 class DummyAgentNotPickleable(AgentWithSimplePolicy):
     def __init__(self, env, **kwargs):
-        AgentWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        AgentWithSimplePolicy.__init__(self, env, writer_extra="reward", **kwargs)
 
         self.name = "DummyAgent"
         self.fitted = False
@@ -470,8 +468,7 @@ class DummyAgentNotPickleable(AgentWithSimplePolicy):
 
 class DummyAgentNotPickleableTorch(AgentTorch):
     def __init__(self, env, **kwargs):
-        AgentWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        AgentWithSimplePolicy.__init__(self, env, writer_extra="reward", **kwargs)
 
         self.name = "DummyAgent"
         self.fitted = False

--- a/rlberry/manager/tests/test_plot.py
+++ b/rlberry/manager/tests/test_plot.py
@@ -7,7 +7,6 @@ import pandas as pd
 import sys
 import matplotlib.pyplot as plt
 
-from rlberry.wrappers import WriterWrapper
 from rlberry_scool.envs import Chain
 from rlberry.manager import plot_writer_data, ExperimentManager, read_writer_data
 from rlberry.manager.plotting import plot_smoothed_curves, plot_synchronized_curves
@@ -20,8 +19,7 @@ class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"
 
     def __init__(self, env, **kwargs):
-        AgentWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        AgentWithSimplePolicy.__init__(self, env, writer_extra="reward", **kwargs)
 
     def fit(self, budget=100, **kwargs):
         observation, info = self.env.reset()

--- a/rlberry/utils/tests/test_loading_tools.py
+++ b/rlberry/utils/tests/test_loading_tools.py
@@ -3,7 +3,6 @@ from rlberry.agents import AgentWithSimplePolicy
 from rlberry.utils import loading_tools
 from rlberry.manager import ExperimentManager
 from rlberry_scool.envs import Chain
-from rlberry.wrappers import WriterWrapper
 import tempfile
 import numpy as np
 import time
@@ -13,8 +12,7 @@ class RandomAgent(AgentWithSimplePolicy):
     name = "RandomAgent"
 
     def __init__(self, env, **kwargs):
-        AgentWithSimplePolicy.__init__(self, env, **kwargs)
-        self.env = WriterWrapper(self.env, self.writer, write_scalar="reward")
+        AgentWithSimplePolicy.__init__(self, env, writer_extra="reward", **kwargs)
 
     def fit(self, budget=100, **kwargs):
         observation, info = self.env.reset()

--- a/rlberry/wrappers/tests/test_writer_utils.py
+++ b/rlberry/wrappers/tests/test_writer_utils.py
@@ -1,19 +1,19 @@
 import pytest
 
-from rlberry.wrappers import WriterWrapper
 from rlberry_scool.envs import GridWorld
 
 from rlberry_scool.agents import UCBVIAgent
 
 
-@pytest.mark.parametrize("write_scalar", ["action", "reward", "action_and_reward"])
+@pytest.mark.parametrize(
+    "write_scalar", [None, "action", "reward", "action_and_reward"]
+)
 def test_wrapper(write_scalar):
     """Test that the wrapper record data"""
 
     class MyAgent(UCBVIAgent):
         def __init__(self, env, **kwargs):
-            UCBVIAgent.__init__(self, env, **kwargs)
-            self.env = WriterWrapper(self.env, self.writer, write_scalar=write_scalar)
+            UCBVIAgent.__init__(self, env, writer_extra=write_scalar, **kwargs)
 
     env = GridWorld()
     agent = MyAgent(env)
@@ -26,8 +26,7 @@ def test_invalid_wrapper_name():
 
     class MyAgent(UCBVIAgent):
         def __init__(self, env, **kwargs):
-            UCBVIAgent.__init__(self, env, **kwargs)
-            self.env = WriterWrapper(self.env, self.writer, write_scalar="invalid")
+            UCBVIAgent.__init__(self, env, writer_extra="invalid", **kwargs)
 
     msg = "write_scalar invalid is not known"
     env = GridWorld()


### PR DESCRIPTION
Integrates the writer directly into the base "Agent" via an option. 
Should solve (at least for the writer)  #457



## Checklist
- \[x] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[x] I have made corresponding changes to the documentation,
- \[x] I have added tests that prove my fix is effective or that my feature works,
- \[x] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.
-->
