### PR TITLE
Change triggers from "ready fo rreview"  to  "ready for CI" 

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ To check :
 - \[ ] I have made corresponding changes to the documentation,
 - \[ ] I have added tests that prove my fix is effective or that my feature works,
 - \[ ] New and existing unit tests pass locally with my changes,
-- \[ ] I have updated updated the changelog if necessary,
-- \[ ] I have set the label "ready for CI" and the checks are all green.
-- \[ ] I have set the label "ready for review"
-- \[ ] I have made corresponding changes based on the reviews
+- \[ ] I have updated the changelog if necessary,
+- \[ ] I have set the label "ready for CI" and the checks are all green,
+- \[ ] I have set the label "ready for review",
+- \[ ] I made the changes suggested during the reviews,
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ To check :
 - \[ ] I have made corresponding changes to the documentation,
 - \[ ] I have added tests that prove my fix is effective or that my feature works,
 - \[ ] New and existing unit tests pass locally with my changes,
-- \[ ] If updated the changelog if necessary,
+- \[ ] I have updated updated the changelog if necessary,
 - \[ ] I have set the label "ready for CI" and the checks are all green.
 - \[ ] I have set the label "ready for review"
 - \[ ] I have made corresponding changes based on the reviews

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,5 +17,7 @@ To check :
 - \[ ] I have added tests that prove my fix is effective or that my feature works,
 - \[ ] New and existing unit tests pass locally with my changes,
 - \[ ] If updated the changelog if necessary,
-- \[ ] I have set the label "ready for review" and the checks are all green.
+- \[ ] I have set the label "ready for CI" and the checks are all green.
+- \[ ] I have set the label "ready for review"
+- \[ ] I have made corresponding changes based on the reviews
 -->

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@ name: "preview"
 
 on:
   workflow_run:
-    workflows: ["ready_for_review"]
+    workflows: ["ready_for_CI"]
     types:
       - completed
 

--- a/.github/workflows/ready_for_CI.yml
+++ b/.github/workflows/ready_for_CI.yml
@@ -1,4 +1,4 @@
-name: ready_for_review
+name: ready_for_CI
 
 on:
   pull_request:

--- a/.github/workflows/ready_for_review.yml
+++ b/.github/workflows/ready_for_review.yml
@@ -6,13 +6,13 @@ on:
 
 jobs:
   build:
-    if: contains( github.event.pull_request.labels.*.name, 'ready for review')
+    if: contains( github.event.pull_request.labels.*.name, 'ready for CI')
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v4
     - name: Run a one-line script
-      run: echo ready for review!
+      run: echo ready for CI!
     - name: Save the PR number in an artifact
       shell: bash
       env:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,10 +19,10 @@ jobs:
   steps:
   - bash: |
      echo "Looking for label at https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels"
-     if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "ready for review"'
+     if curl -s "https://api.github.com/repos/$BUILD_REPOSITORY_ID/issues/$SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/labels" | grep '"name": "ready for CI"'
      then
        echo "##vso[task.setvariable variable=prHasCILabel;isOutput=true]true"
-       echo "[INFO] ready for review label found!"
+       echo "[INFO] ready for CI label found!"
      fi
     displayName: Check for CI label build on PR
     condition: eq(variables['Build.Reason'], 'PullRequest') # only run step if it is a PR
@@ -30,7 +30,7 @@ jobs:
 
 - job: 'linux'
   dependsOn: checkPrLabel
-  # Condition: have ready for review label or on the main branch.
+  # Condition: have ready for CI label or on the main branch.
   condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
   pool:
     vmImage: ubuntu-latest
@@ -159,7 +159,7 @@ jobs:
 
 - job: 'linux_non_editable'
   dependsOn: checkPrLabel
-  # Condition: have ready for review label or on the main branch.
+  # Condition: have ready for CI label or on the main branch.
   condition: or(in(variables['Build.SourceBranch'], 'refs/heads/main'), eq(dependencies.checkPrLabel.outputs['checkPrLabel.prHasCILabel'], true))
   pool:
     vmImage: ubuntu-latest

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,11 +11,9 @@ Dev version
 
 * Update the current "ready for review" to "ready for CI". And add a new "ready for review" that don't trigger the CI.
 
-
  *PR #476*
 
 * Update lib versions and remove warnings from tests/CI : https://github.com/rlberry-py/rlberry/issues/471
-
 
  *PR #474*
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,7 +8,7 @@ Dev version
 -----------
 
  *PR #478*
- 
+
 * Update the current "ready for review" to "ready for CI". And add a new "ready for review" that don't trigger the CI.
 
  *PR #477*

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -7,6 +7,10 @@ Changelog
 Dev version
 -----------
 
+ *PR #478*
+
+* Update the current "ready for review" to "ready for CI". And add a new "ready for review" that don't trigger the CI.
+
  *PR #474*
 
 * Create a new tool to load data from tensorboard logs : https://github.com/rlberry-py/rlberry/issues/472

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,7 +17,7 @@ Please read the rest of this page for more information on how to contribute to
 rlberry and look at our [beginner developer guide](dev_guide) if you have questions
 about how to use git, do PR or for more informations about the documentation.
 
-For a PR to be accepted it must pass all the tests when the label 'ready for review' is set in the PR. The label 'ready for review' trigger additional tests to be done on the PR and should be set when the PR is ready.
+For a PR to be accepted it must pass all the tests when the label 'ready for CI' is set in the PR. The label 'ready for CI' trigger additional tests to be done on the PR and should be set when the PR is ready.
 
 ## Documentation
 


### PR DESCRIPTION
add a label "ready for CI" 
and switch the CI trigger on it

- \[ ] My code follows the style guideline
To check :
   black --check examples rlberry *py
   flake8 --select F401,F405,D410,D411,D412 --exclude=rlberry/check_packages.py --per-file-ignores="__init__.py:F401",
- \[ ] I have commented my code, particularly in hard-to-understand areas,
- \[ ] I have made corresponding changes to the documentation,
- \[ ] I have added tests that prove my fix is effective or that my feature works,
- \[ ] New and existing unit tests pass locally with my changes,
- \[x] If updated the changelog if necessary,
- \[x] I have set the label "ready for review" and the checks are all green.

